### PR TITLE
feat: implement buildUrl helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ In a component:
     :src="advancedSrcObject.src"
     :srcset="advancedSrcObject.srcset"
     sizes="50vw"
-    data-testid="advanced-basic-image"
   />
 </template>
 
@@ -104,6 +103,36 @@ In a component:
   };
 </script>
 ```
+
+#### buildUrl
+
+In addition to the helper above, we provide `buildURL` from imgix-core-js to help developers to create any URL they need.
+
+
+```html
+<template>
+  <img
+    :src="advancedUrl"
+  />
+</template>
+
+<script>
+  import { buildUrl } from '@/plugins/vue-imgix';
+
+  // NB: Make sure initVueImgix has been called before this code runs
+  export default {
+    name: 'advanced-build-url',
+
+    computed: {
+      advancedUrl: () =>
+        buildUrl('examples/pione.jpg', {
+          auto: 'format',
+        }),
+    },
+  };
+</script>
+```
+
 
 ## Contributing
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,17 +3,21 @@
     <h1>Advanced Usage</h1>
     <h2>buildUrlObject</h2>
     <advanced-build-url-object></advanced-build-url-object>
+    <h2>buildUrl</h2>
+    <advanced-build-url />
   </div>
 </template>
 
 <script>
 import advancedBuildUrlObject from './components/advanced/buildUrlObject';
+import advancedBuildUrl from './components/advanced/buildUrl';
 
 export default {
   name: 'App',
 
   components: {
     advancedBuildUrlObject,
+    advancedBuildUrl,
   },
 
   computed: {},

--- a/src/components/advanced/buildUrl.vue
+++ b/src/components/advanced/buildUrl.vue
@@ -1,0 +1,20 @@
+<template>
+  <img :src="advancedUrl" data-testid="advanced-build-url" />
+</template>
+
+<script>
+import { buildUrl } from '@/plugins/vue-imgix';
+
+// NB: Make sure initVueImgix has been called before this code runs
+export default {
+  name: 'advanced-build-url',
+
+  computed: {
+    advancedUrl: () =>
+      buildUrl('examples/pione.jpg', {
+        auto: 'format',
+        w: 400,
+      }),
+  },
+};
+</script>

--- a/src/plugins/vue-imgix/types.ts
+++ b/src/plugins/vue-imgix/types.ts
@@ -1,3 +1,5 @@
+export type IImgixParams = {};
+
 export interface IImgixClientOptions {
   domain: string;
 }
@@ -8,9 +10,12 @@ export interface IBuildUrlObjectResult {
 }
 export type IBuildUrlObject = (
   url: string,
-  options?: {},
+  options?: IImgixParams,
 ) => IBuildUrlObjectResult;
+
+export type IBuildUrl = (url: string, options?: IImgixParams) => string;
 
 export interface IVueImgixClient {
   buildUrlObject: IBuildUrlObject;
+  buildUrl: IBuildUrl;
 }

--- a/src/plugins/vue-imgix/vue-imgix.ts
+++ b/src/plugins/vue-imgix/vue-imgix.ts
@@ -1,8 +1,10 @@
 import ImgixClient from 'imgix-core-js';
 import {
+  IBuildUrl,
   IBuildUrlObject,
   IBuildUrlObjectResult,
   IImgixClientOptions,
+  IImgixParams,
   IVueImgixClient,
 } from './types';
 
@@ -19,11 +21,15 @@ class VueImgixClient implements IVueImgixClient {
     (this.client as any).settings.libraryParam = `vue-${VERSION}`;
   }
 
-  buildUrlObject(url: string, options?: {}): IBuildUrlObjectResult {
+  buildUrlObject(url: string, options?: IImgixParams): IBuildUrlObjectResult {
     const src = this.client.buildURL(url, options);
     const srcset = this.client.buildSrcSet(url, options);
 
     return { src, srcset };
+  }
+
+  buildUrl(url: string, options?: IImgixParams): string {
+    return this.client.buildURL(url, options);
   }
 }
 
@@ -53,6 +59,11 @@ const ensureVueImgixClientSingleton = (): IVueImgixClient => {
 export const buildUrlObject: IBuildUrlObject = (...args) => {
   const client = ensureVueImgixClientSingleton();
   return client.buildUrlObject(...args);
+};
+
+export const buildUrl: IBuildUrl = (...args) => {
+  const client = ensureVueImgixClientSingleton();
+  return client.buildUrl(...args);
 };
 
 export { IVueImgixClient };

--- a/tests/e2e/specs/advanced-api.spec.js
+++ b/tests/e2e/specs/advanced-api.spec.js
@@ -2,10 +2,13 @@ describe('Advanced API', () => {
   before(() => {
     cy.fixture('test-image').as('testImage');
   });
-  it('renders an image', () => {
-    cy.visit('/');
-    cy.findByTestId('advanced-basic-image').then($image => {
-      expect($image.attr('src')).to.match(/ixlib=vue/);
+
+  context('buildUrlObject', () => {
+    it('renders an image', () => {
+      cy.visit('/');
+      cy.findByTestId('advanced-basic-image').then($image => {
+        expect($image.attr('src')).to.match(/ixlib=vue/);
+      });
     });
   });
 });

--- a/tests/e2e/specs/advanced-api.spec.js
+++ b/tests/e2e/specs/advanced-api.spec.js
@@ -11,4 +11,13 @@ describe('Advanced API', () => {
       });
     });
   });
+
+  context('buildUrl', () => {
+    it('renders an image', () => {
+      cy.visit('/');
+      cy.findByTestId('advanced-build-url').then($image => {
+        expect($image.attr('src')).to.match(/ixlib=vue/);
+      });
+    });
+  });
 });

--- a/tests/unit/build-url-spec.ts
+++ b/tests/unit/build-url-spec.ts
@@ -1,0 +1,18 @@
+import {
+  buildImgixClient,
+  IVueImgixClient,
+} from '@/plugins/vue-imgix/vue-imgix';
+
+describe('buildUrlObject', () => {
+  let client: IVueImgixClient;
+  beforeAll(() => {
+    client = buildImgixClient({
+      domain: 'assets.imgix.net',
+    });
+  });
+
+  it('builds an imgix url', () => {
+    const url = client.buildUrl('/examples/pione.jpg', {});
+    expect(url).toMatch(/assets.imgix.net\/examples\/pione.jpg/);
+  });
+});


### PR DESCRIPTION
This PR implements the second part of the advanced api, `buildUrl`, which is simply a re-export of buildUrl from `imgix-core-js`.