### PR TITLE
config: setup semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,9 @@ script:
   - yarn lint:ci
   - yarn test:unit
   - yarn test:e2e --headless
+
+deploy:
+  provider: script
+  skip_cleanup: true
+  script:
+    - npx semantic-release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-imgix",
-  "version": "0.1.0",
+  "version": "0.0.0-development",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
@@ -38,5 +38,14 @@
     "read-pkg": "^5.2.0",
     "typescript": "~3.8.3",
     "vue-template-compiler": "^2.6.11"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/imgix/vue-imgix.git"
+  },
+  "release": {
+    "branches": [
+      "next"
+    ]
   }
 }

--- a/src/plugins/vue-imgix/vue-imgix.ts
+++ b/src/plugins/vue-imgix/vue-imgix.ts
@@ -8,7 +8,7 @@ import {
   IVueImgixClient,
 } from './types';
 
-const VERSION = '0.1.0';
+const VERSION = '0.0.0-development';
 
 class VueImgixClient implements IVueImgixClient {
   client: ImgixClient;


### PR DESCRIPTION
This PR sets up semantic release to automatically publish the `next` branch to NPM under the `next` distribution channel. The `next` distribution channel is **not** installed by default when a user installs vue-imgix with `npm install vue-imgix`.

For now, we will have to manually deploy any releases on the `master` branch. I will work how to do this with semantic-release. In the future, if we are comfortable with semantic-release, we can enable automatic deployments on master too, and still have this flow.

This way, we still get to test how automatic deployment works, while still having control of what end users install.

We could potentially use `next` as an internal beta channel, if we wanted.

I decided that this was the best way to get started with automatic deployment, but also have it not be too risky.

There's more information on Paper, look for "Continuous Delivery for SDK libraries".