### PR TITLE
feat: allow developers to set default imgix parameters globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,13 @@ import VueImgix from 'vue-imgix';
 
 Vue.use(VueImgix, {
   domain: "<your company's imgix domain>",
+  defaultIxParams: {
+    auto: 'format',
+  },
 });
 ```
+
+**NB:** This enables the [auto format imgix parameter](https://docs.imgix.com/apis/url/auto/auto#format) by default for all images, which we recommend to reduce image size, but you might choose to turn this off.
 
 And that's all you need to get started! Have fun!
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,9 @@ Vue.config.productionTip = false;
 
 Vue.use(VueImgix, {
   domain: 'assets.imgix.net',
+  defaultIxParams: {
+    auto: 'format',
+  },
 });
 
 new Vue({

--- a/src/plugins/vue-imgix/types.ts
+++ b/src/plugins/vue-imgix/types.ts
@@ -3,6 +3,7 @@ export type IImgixParams = {};
 export interface IImgixClientOptions {
   domain: string;
   includeLibraryParam?: boolean;
+  defaultIxParams?: IImgixParams;
 }
 
 export interface IBuildUrlObjectResult {

--- a/src/plugins/vue-imgix/vue-imgix.ts
+++ b/src/plugins/vue-imgix/vue-imgix.ts
@@ -23,35 +23,40 @@ class VueImgixClient implements IVueImgixClient {
   constructor(options: IImgixClientOptions) {
     this.options = { ...clientOptionDefaults, ...options };
 
-    const { includeLibraryParam, ...imgixClientOptions } = this.options;
-
     this.client = new ImgixClient({
-      ...imgixClientOptions,
+      domain: this.options.domain,
       includeLibraryParam: false, // force false so that imgix-core-js doesn't include its own library param
     });
     // This is not a public API, so it is not included in the type definitions for ImgixClient
-    if (includeLibraryParam) {
+    if (this.options.includeLibraryParam) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (this.client as any).settings.libraryParam = `vue-${VERSION}`;
     }
   }
 
+  buildIxParams = (ixParams?: IImgixParams) => {
+    return {
+      ...this.options.defaultIxParams,
+      ...ixParams,
+    };
+  };
+
   buildUrlObject = (
     url: string,
-    options?: IImgixParams,
+    ixParams?: IImgixParams,
   ): IBuildUrlObjectResult => {
-    const src = this.client.buildURL(url, options);
-    const srcset = this.client.buildSrcSet(url, options);
+    const src = this.buildUrl(url, ixParams);
+    const srcset = this.buildSrcSet(url, ixParams);
 
     return { src, srcset };
   };
 
-  buildUrl = (url: string, options?: IImgixParams): string => {
-    return this.client.buildURL(url, options);
+  buildUrl = (url: string, ixParams?: IImgixParams): string => {
+    return this.client.buildURL(url, this.buildIxParams(ixParams));
   };
 
-  buildSrcSet = (url: string, options?: IImgixParams): string => {
-    return this.client.buildSrcSet(url, options);
+  buildSrcSet = (url: string, ixParams?: IImgixParams): string => {
+    return this.client.buildSrcSet(url, this.buildIxParams(ixParams));
   };
 }
 

--- a/tests/unit/initialization.spec.ts
+++ b/tests/unit/initialization.spec.ts
@@ -32,4 +32,21 @@ describe('Initialization', () => {
       srcset: expect.not.stringMatching(/ixlib/),
     });
   });
+
+  it(`includes imgixParams set during initialization in the generated srcs`, () => {
+    const Vue = require('vue');
+    const VueImgix = require('@/plugins/vue-imgix');
+    Vue.use(VueImgix, {
+      domain: 'test-domain.imgix.net',
+      defaultIxParams: {
+        auto: 'format',
+      },
+    });
+
+    const { buildUrlObject } = require('@/plugins/vue-imgix');
+    expect(buildUrlObject('/test-image.jpg')).toMatchObject({
+      src: expect.stringMatching(/auto=format/),
+      srcset: expect.stringMatching(/auto=format/),
+    });
+  });
 });


### PR DESCRIPTION
This is done with the code
```js
Vue.use(VueImgix, {
  defaultIxParams: {
    auto: "format"
  }
});
```