### PR TITLE
config: change semantic config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ deploy:
   script:
     - npx semantic-release
   on:
-    branch: next
+    all_branches: true

--- a/package.json
+++ b/package.json
@@ -75,14 +75,7 @@
     "vue-property-decorator": "8.4.2",
     "vue-template-compiler": "2.6.11"
   },
-  "release": {
-    "branches": [
-      {
-        "name": "next",
-        "channel": "next"
-      }
-    ]
-  },
+  "release": {},
   "files": [
     "/dist",
     "/src/plugins/vue-imgix",


### PR DESCRIPTION
This PR updates the semantic config to use the default config so we can use continuous deployment for stable builds.