### PR TITLE
feat: add fixed prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ To render a simple image that will display an image based on the browser's dpr a
 
 [![Edit festive-mclean-6risg](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/festive-mclean-6risg?fontsize=14&hidenavigation=1&theme=dark)
 
-**Please note:** `100vw` is an appropriate `sizes` value for a full-bleed image. If your image is not full-bleed, you should use a different value for `sizes`. [Eric Portis' "Srcset and sizes"](https://ericportis.com/posts/2014/srcset-sizes/) article goes into depth on how to use the `sizes` attribute.
+**Please note:** `100vw` is an appropriate `sizes` value for a full-bleed image. If your image is not full-bleed, you should use a different value for `sizes`. [Eric Portis' "Srcset and sizes"](https://ericportis.com/posts/2014/srcset-sizes/) article goes into depth on how to use the `sizes` attribute. An important note here is that **sizes cannot be a percentage based value**, and must be in terms of vw, or a fixed size (px, em, rem, etc)
 
 This will generate HTML similar to the following:
 
@@ -178,26 +178,36 @@ This component acts dynamically by default. The component will leverage `srcset`
 
 `sizes` should be set properly for this to work well, and some styling should be used to set the size of the component rendered. Without `sizes` and correct styling the image might render at full-size.
 
+✨**There is new browser behavior in 2019/2020.** It is now recommended that `width` and `height` be set on all images to provide an aspect ratio hint to the browser. The browser can then use this aspect ratio hint to reserve a space for the image (even if the image is responsive!). The following example explains all how to do it. You can also read more about this development [in this amazing Smashing Magazine article.](https://www.smashingmagazine.com/2020/03/setting-height-width-images-important-again/)
+
+For the width/height placeholder image, we need three requirements to be met:
+
+- `width` and `height` attributes set on the img element
+- some `width` CSS value (e.g. `10px`, `100%`, `calc(100vw - 10px)`)
+- `height: auto` as a CSS property
+
 `./styles.css`
 
 ```css
-.App {
-  display: flex;
-}
-
-.App > img {
-  margin: 10px auto;
-  width: 10vw;
-  height: 200px;
+.test-img {
+  /* These next two lines are critical for the new browser feature. */
+  width: calc(100vw - 128px);
+  height: auto; // This tells the browser to set the height of the image to what it should be, and ignore the height attribute set on the image
 }
 ```
 
 `./app.js`
 
+For the width and height attributes, they can be any value as long as their aspect ratio is the same as what the image's aspect ratio is. E.g. `width = 100, height = 50` is fine, and also `width = 2, height = 1` is fine. In this case, the image has an aspect ratio of ~0.66:1, so we have set set a width of 66 and a height of 100, but we could have also used a width and height of 33 and 50, or 660 and 1000, for example.
+
 ```html
-<div className="App">
-  <ix-img src="examples/pione.jpg" sizes="calc(10% - 10px)" />
-</div>
+<ix-img 
+  src="examples/pione.jpg" 
+  sizes="calc(100vw - 128px)" 
+  class="test-img"
+  width="66"
+  height="100"
+/>
 ```
 
 **Aspect Ratio:** A developer can pass a desired aspect ratio, which will be used when
@@ -207,8 +217,10 @@ generating srcsets to resize and crop your image as specified. For the `ar` para
 <div className="App">
   <ix-img
     src="examples/pione.jpg"
-    sizes="calc(10% - 10px)"
+    sizes="calc(100vw - 128px)"
     imgixParams="{ ar: '16:9', fit: 'crop' }"
+    width="16" // It's important to set these attributes to the aspect ratio that we manually specify.
+    height="9"
   />
 </div>
 ```
@@ -217,13 +229,25 @@ The aspect ratio is specified in the format `width:height`. Either dimension can
 
 #### Fixed Image Rendering (i.e. non-flexible)
 
-If the fluid, dynamic nature explained above is not desired, the width and height can be set explicitly.
+If the fluid, dynamic nature explained above is not desired, the width and height can be set explicitly along with a `fixed` prop. The imgix CDN will then render an image with these exact dimensions
 
 ```js
 <ix-img
-  src="examples/pione.jpg"
-  width="100" // This sets what resolution the component should load from the CDN and the size of the resulting image
+  src="image.jpg"
+  width="100" // This width and the height below sets what resolution the component should load from the CDN and the size of the resulting image
   height="200"
+  fixed
+/>
+```
+
+This will generate an image element like:
+
+```jsx
+<ix-img 
+  src="image.jpg?w=100&h=200" // Notice the w and h parameters here
+  srcset="image.jpg?w=100&h=200&dpr=1 1x, image.jpg?w=100&h=200&dpr=2 2x, ..." // This allows the image to respond to different device dprs
+  width="100" 
+  height="200" 
 />
 ```
 

--- a/src/components/simple/simple.vue
+++ b/src/components/simple/simple.vue
@@ -6,6 +6,7 @@
     <ix-img
       src="examples/pione.jpg"
       width="100"
+      fixed
       data-testid="simple-fixed-width"
     />
     <h2>Picture</h2>

--- a/src/plugins/vue-imgix/ix-img.tsx
+++ b/src/plugins/vue-imgix/ix-img.tsx
@@ -1,7 +1,4 @@
-import {
-  ensureVueImgixClientSingleton,
-  IVueImgixClient,
-} from '@/plugins/vue-imgix/vue-imgix';
+import { ensureVueImgixClientSingleton, IVueImgixClient } from '@/plugins/vue-imgix/vue-imgix';
 import Vue, { CreateElement } from 'vue';
 import Component from 'vue-class-component';
 
@@ -11,6 +8,7 @@ const IxImgProps = Vue.extend({
       type: String,
       required: true,
     },
+    fixed: Boolean,
     imgixParams: Object,
     width: [String, Number],
     height: [String, Number],
@@ -34,8 +32,10 @@ export class IxImg extends IxImgProps {
 
   render(createElement: CreateElement) {
     const imgixParamsFromImgAttributes = {
-      ...(this.width != null ? { w: this.width } : {}),
-      ...(this.height != null ? { h: this.height } : {}),
+      ...(this.fixed && {
+        ...(this.width != null ? { w: this.width } : {}),
+        ...(this.height != null ? { h: this.height } : {}),
+      }),
     };
 
     const { src, srcset } = this.vueImgixSingleton.buildUrlObject(this.src, {

--- a/src/plugins/vue-imgix/ix-img.tsx
+++ b/src/plugins/vue-imgix/ix-img.tsx
@@ -1,4 +1,7 @@
-import { ensureVueImgixClientSingleton, IVueImgixClient } from '@/plugins/vue-imgix/vue-imgix';
+import {
+  ensureVueImgixClientSingleton,
+  IVueImgixClient,
+} from '@/plugins/vue-imgix/vue-imgix';
 import Vue, { CreateElement } from 'vue';
 import Component from 'vue-class-component';
 

--- a/tests/helpers/url-assert.ts
+++ b/tests/helpers/url-assert.ts
@@ -1,0 +1,54 @@
+export const stringMatchingFixedSrcSet = (width: number) =>
+  expect.stringMatching(new RegExp(`.*w=${width}&.*dpr=1.* 1x,`));
+
+export const expectSrcSetToBeFixed = (
+  srcset: string | null | undefined,
+  width: number,
+) => expect(srcset).toEqual(stringMatchingFixedSrcSet(width));
+
+export const expectElementToHaveFixedSrcSet = (
+  el: HTMLElement,
+  width: number,
+) => expectSrcSetToBeFixed(el.getAttribute('srcset'), width);
+
+export const stringMatchingFixedSrc = (width: number) =>
+  expect.stringMatching(new RegExp(`.*w=${width}`));
+
+export const expectSrcToBeFixed = (
+  src: string | null | undefined,
+  width: number,
+) => expect(src).toEqual(stringMatchingFixedSrc(width));
+
+export const expectElementToHaveFixedSrc = (el: HTMLElement, width: number) =>
+  expectSrcToBeFixed(el.getAttribute('src'), width);
+
+export const expectElementToHaveFixedSrcAndSrcSet = (
+  el: HTMLElement,
+  width: number,
+) => {
+  expectElementToHaveFixedSrc(el, width);
+  expectElementToHaveFixedSrcSet(el, width);
+};
+
+export const stringMatchingFluidSrcSet = () =>
+  expect.stringMatching(new RegExp(`.*w=100.* 100w,`));
+
+export const expectSrcSetToBeFluid = (srcset: string | null | undefined) =>
+  expect(srcset).toEqual(stringMatchingFluidSrcSet());
+
+export const expectElementToHaveFluidSrcSet = (el: HTMLElement) =>
+  expectSrcSetToBeFluid(el.getAttribute('srcset'));
+
+export const stringMatchingFluidSrc = () =>
+  expect.stringMatching(new RegExp(`^(?!.*w=).*$`));
+
+export const expectSrcToBeFluid = (src: string | null | undefined) =>
+  expect(src).toEqual(stringMatchingFluidSrc());
+
+export const expectElementToHaveFluidSrc = (el: HTMLElement) =>
+  expectSrcToBeFluid(el.getAttribute('src'));
+
+export const expectElementToHaveFluidSrcAndSrcSet = (el: HTMLElement) => {
+  expectElementToHaveFluidSrc(el);
+  expectElementToHaveFluidSrcSet(el);
+};

--- a/tests/unit/imgix-component.spec.ts
+++ b/tests/unit/imgix-component.spec.ts
@@ -2,7 +2,10 @@ import VueImgix, { IxImg } from '@/plugins/vue-imgix';
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/vue';
 import Vue from 'vue';
-import { expectElementToHaveFixedSrcAndSrcSet, expectElementToHaveFluidSrcAndSrcSet } from '../helpers/url-assert';
+import {
+  expectElementToHaveFixedSrcAndSrcSet,
+  expectElementToHaveFluidSrcAndSrcSet,
+} from '../helpers/url-assert';
 describe('imgix component', () => {
   beforeAll(() => {
     Vue.use(VueImgix, {

--- a/tests/unit/imgix-component.spec.ts
+++ b/tests/unit/imgix-component.spec.ts
@@ -2,6 +2,7 @@ import VueImgix, { IxImg } from '@/plugins/vue-imgix';
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/vue';
 import Vue from 'vue';
+import { expectElementToHaveFixedSrcAndSrcSet, expectElementToHaveFluidSrcAndSrcSet } from '../helpers/url-assert';
 describe('imgix component', () => {
   beforeAll(() => {
     Vue.use(VueImgix, {
@@ -73,8 +74,23 @@ describe('imgix component', () => {
     );
   });
 
-  describe('in fixed mode (width or height passed to url, imgixParams, or dom attribute)', () => {
-    it('when a width passed to imgixParams, the srcset is in fixed size mode', () => {
+  describe('in fluid mode (no fixed props set)', () => {
+    it('ix-img should render a fluid image if width is passed as attribute', () => {
+      const wrapper = render(IxImg, {
+        propsData: {
+          'data-testid': 'img-rendering',
+          src: 'examples/pione.jpg',
+          width: 100,
+        },
+      });
+
+      const el = wrapper.getByTestId('img-rendering');
+      expectElementToHaveFluidSrcAndSrcSet(el);
+    });
+  });
+
+  describe('in fixed mode (fixed prop set, or width/height passed to imgixParams)', () => {
+    it('when a width passed to imgixParams, the src and srcset are is in fixed size mode', () => {
       const wrapper = render(IxImg, {
         propsData: {
           'data-testid': 'img-rendering',
@@ -85,49 +101,25 @@ describe('imgix component', () => {
         },
       });
 
-      expect(wrapper.getByTestId('img-rendering')).toHaveAttribute(
-        'src',
-        expect.stringMatching('w=100'),
-      );
-      const srcset = wrapper
-        .getByTestId('img-rendering')
-        .getAttribute('srcset');
-
-      expect(srcset).not.toBeFalsy();
-      if (!srcset) {
-        fail('srcset is null');
-      }
-      const firstSrcSet = srcset.split(',').map((v) => v.trim())[0];
-      expect(firstSrcSet).toMatch('w=100');
-      expect(firstSrcSet).toMatch('dpr=1');
-      expect(firstSrcSet).toMatch(' 1x');
+      const el = wrapper.getByTestId('img-rendering');
+      expectElementToHaveFixedSrcAndSrcSet(el, 100);
     });
-
-    it('when a width passed to element, the srcset is in fixed size mode', () => {
+    it('when a fixed prop is passed tothe element, the src and srcset is in fixed size mode', () => {
       const wrapper = render(IxImg, {
         propsData: {
           'data-testid': 'img-rendering',
           src: 'examples/pione.jpg',
           width: 100,
+          height: 150,
+          fixed: true,
         },
       });
 
-      expect(wrapper.getByTestId('img-rendering')).toHaveAttribute(
-        'src',
-        expect.stringMatching('w=100'),
-      );
-      const srcset = wrapper
-        .getByTestId('img-rendering')
-        .getAttribute('srcset');
+      const el = wrapper.getByTestId('img-rendering');
+      expectElementToHaveFixedSrcAndSrcSet(el, 100);
 
-      expect(srcset).not.toBeFalsy();
-      if (!srcset) {
-        fail('srcset is null');
-      }
-      const firstSrcSet = srcset.split(',').map((v) => v.trim())[0];
-      expect(firstSrcSet).toMatch('w=100');
-      expect(firstSrcSet).toMatch('dpr=1');
-      expect(firstSrcSet).toMatch(' 1x');
+      expect(el).toHaveAttribute('src', expect.stringMatching('h=150'));
+      expect(el).toHaveAttribute('srcset', expect.stringMatching('h=150'));
     });
 
     it('a width attribute is passed through to the underlying component', () => {


### PR DESCRIPTION
This PR follows on from internal discussions about how to best handle the new aspect-ratio placeholder behaviour of modern browsers. We agreed that the best way to handle this was with a `fixed` prop. The idea is that if this prop isn't present (i.e. by default), the image will render in responsive mode. This allows the user to pass a width and height (as they would for a normal `<img>`), and have it specify a responsive-aware placeholder for the image before it is loaded. Previously this was incompatible with our API because the width and height would instead load a fixed-size image. Now, developers will have to pass a `fixed` prop (or, although undocumented, they could also just pass width and height into imgixParams explicitly) for this component to render in a "fixed" mode.