### PR TITLE
chore: update semantic-release plugin order

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "module": "dist/vue-imgix.esm.js",
   "jsnext:main": "dist/vue-imgix.esm.js",
   "unpkg": "dist/vue-imgix.min.js",
-  "version": "0.0.0-development",
+  "version": "2.8.0-beta.1",
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "rollup --config build/rollup.config.js",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,8 @@
           ]
         }
       ],
+      "@semantic-release/npm",
+      "@semantic-release/changelog",
       [
         "@semantic-release/git",
         {
@@ -116,7 +118,6 @@
           "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
         }
       ],
-      "@semantic-release/npm",
       [
         "@semantic-release/github",
         {
@@ -135,8 +136,7 @@
             }
           ]
         }
-      ],
-      "@semantic-release/changelog"
+      ]
     ]
   },
   "files": [


### PR DESCRIPTION
The package.json version wasn't being updated, so I fixed it.