### PR TITLE
Add tags to ignore all-contributors table on docs.imgix.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,8 @@ This code of conduct applies to all imgix sponsored spaces both online and off, 
 
 Contributions are a vital part of this library and imgix's commitment to open-source. We welcome all contributions which align with this project's goals. More information can be found in the [contributing documentation](CONTRIBUTING.md).
 
+<!-- ix-docs-ignore -->
+
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
@@ -664,6 +666,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- prettier-ignore-end -->
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
+<!-- /ix-docs-ignore -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
 


### PR DESCRIPTION
<!-- prettier-ignore-start -->
## Description
<!-- What is accomplished by this PR? If there is something potentially controversial in your PR, please take a moment to tell us about your choices. -->

This PR adds a pair of `<!-- ix-docs-ignore -->` comments around the table in the "Contributors" section of the README.md doc. We've decided that trying to render All-Contributor's table layout nicely is too much effort (since we have no control over the markup) when rendering our SDK READMEs directly on docs.imgix.com. The tags added in this PR will instruct the build pipeline over on the Docs side to ignore the annotated section.

<!-- 
Please use the checklist that is most closely related to your PR, and delete the other checklists. -->
## Checklist: Fixing typos/Doc change

- [x] The target branch is `beta`. This is important for our CI/CD config.
- [x] Each commit follows the conventional commit spec format: e.g. `chore(readme): fixed typo`. See the end of this file for more information.

<!--

## Conventional Commit Spec

PR titles should be in the format `<type>(<scope>): <description>`. For example: `chore(readme): fix typo`

`type` can be one of `feat`, `fix`, `test`, or `chore`.
`scope` is optional, and can be anything.
`description` should be a short description of the change, in past tense.
-->
<!-- prettier-ignore-end -->
