### PR TITLE
docs(readme): correct small typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@
 
 ## Overview / Resources
 
-**Before you get started with vue-imgix**, it's _highly recommended_ that you read Eric Portis' [seminal article on `srcset` and `sizes`](https://ericportis.com/posts/2014/srcset-sizes/). This article explains the history of responsive images in responsive design, why they're necessary, and how all these technologies work together to save bandwidth and provide a better experience for users. The primary goal of react-imgix is to make these tools easier for developers to implement, so having an understanding of how they work will significantly improve your react-imgix experience.
+**Before you get started with vue-imgix**, it's _highly recommended_ that you read Eric Portis' [seminal article on `srcset` and `sizes`](https://ericportis.com/posts/2014/srcset-sizes/). This article explains the history of responsive images in responsive design, why they're necessary, and how all these technologies work together to save bandwidth and provide a better experience for users. The primary goal of vue-imgix is to make these tools easier for developers to implement, so having an understanding of how they work will significantly improve your vue-imgix experience.
 
 Below are some other articles that help explain responsive imagery, and how it can work alongside imgix:
 


### PR DESCRIPTION
The purpose of this PR is to correct a small typo in the opening paragraph.
The change makes `react-imgix` say `vue-imgix`. I only found two instances
of "react" here.