### PR TITLE
fix: picture mode throwing error

### DIFF
--- a/src/plugins/vue-imgix/ix-picture.tsx
+++ b/src/plugins/vue-imgix/ix-picture.tsx
@@ -1,8 +1,8 @@
 import {
   ensureVueImgixClientSingleton,
-  IVueImgixClient,
+  IVueImgixClient
 } from '@/plugins/vue-imgix/vue-imgix';
-import Vue from 'vue';
+import Vue, { CreateElement } from 'vue';
 import Component from 'vue-class-component';
 
 const IxPictureProps = Vue.extend({
@@ -18,7 +18,7 @@ export class IxPicture extends IxPictureProps {
     this.vueImgixSingleton = ensureVueImgixClientSingleton();
   }
 
-  render() {
-    return <picture>{this.$slots.default}</picture>;
+  render(createElement: CreateElement) {
+    return createElement('picture', this.$slots.default);
   }
 }

--- a/src/plugins/vue-imgix/ix-picture.tsx
+++ b/src/plugins/vue-imgix/ix-picture.tsx
@@ -1,6 +1,6 @@
 import {
   ensureVueImgixClientSingleton,
-  IVueImgixClient
+  IVueImgixClient,
 } from '@/plugins/vue-imgix/vue-imgix';
 import Vue, { CreateElement } from 'vue';
 import Component from 'vue-class-component';

--- a/src/plugins/vue-imgix/ix-source.tsx
+++ b/src/plugins/vue-imgix/ix-source.tsx
@@ -1,8 +1,8 @@
 import {
   ensureVueImgixClientSingleton,
-  IVueImgixClient,
+  IVueImgixClient
 } from '@/plugins/vue-imgix/vue-imgix';
-import Vue from 'vue';
+import Vue, { CreateElement } from 'vue';
 import Component from 'vue-class-component';
 
 const IxSourceProps = Vue.extend({
@@ -30,7 +30,7 @@ export class IxSource extends IxSourceProps {
     this.vueImgixSingleton = ensureVueImgixClientSingleton();
   }
 
-  render() {
+  render(createElement: CreateElement) {
     const imgixParamsFromAttributes = {};
 
     const { srcset } = this.vueImgixSingleton.buildUrlObject(this.src, {
@@ -47,6 +47,6 @@ export class IxSource extends IxSourceProps {
       [attributeConfig.srcset]: srcset,
     };
 
-    return <source attrs={childAttrs} />;
+    return createElement('source', { attrs: childAttrs });
   }
 }

--- a/src/plugins/vue-imgix/ix-source.tsx
+++ b/src/plugins/vue-imgix/ix-source.tsx
@@ -1,6 +1,6 @@
 import {
   ensureVueImgixClientSingleton,
-  IVueImgixClient
+  IVueImgixClient,
 } from '@/plugins/vue-imgix/vue-imgix';
 import Vue, { CreateElement } from 'vue';
 import Component from 'vue-class-component';


### PR DESCRIPTION
## Description
<!-- What is accomplished by this PR? If there is something potentially controversial in your PR, please take a moment to tell us about your choices. -->

This PR fixes an issue where JSX was being incorrectly used in this project. In development and in the tests this works since it is using the Vue CLI, which transpiles JSX correctly. Unfortunately, the build step processed the JSX differently, which wasn't picked up in testing.

This PR removes JSX from IxPicture and IxSource so that they work correctly.

This fixes #163 

## Checklist: Bug Fix

- [x] Each commit follows the conventional commit spec format: e.g. `chore(readme): fixed typo`. See the end of this file for more information.
- [x] All existing unit tests are still passing (if applicable)
- [N/A] Add new passing unit tests to cover the code introduced by your PR
- [N/A] Update the readme
- [N/A] Update or add any necessary API documentation
- [x] Add some [steps](#steps-to-test) so we can test your bug fix

## Steps to Test

<!-- A code example or a set of steps is preferred -->

Related issue: #163

Code:

```js
<ix-picture>
  <ix-source
    src="examples/pione.jpg"
    media="(min-width: 768px)"
    :imgixParams="{ ar: '2:1', fit: 'crop' }"
  />
  <ix-source
    src="examples/pione.jpg"
    media="(min-width: 320px)"
    :imgixParams="{ ar: '1.5:1' }"
  />
  <ix-img src="examples/pione.jpg" :imgixParams="{ w: 100, ar: '3:1' }" />
</ix-picture>
```

<!-- A link to a codepen/codesandbox is also an option. -->

Steps:

1.  Setup a nuxt project locally
2. 	Build this project and link to the nuxt project
3.	Insert the code onto a page and verify the picture is working.