### PR TITLE
chore: replace ref to master with main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
 
 branches:
   only:
-    - master
+    - main
     - next
     - beta
     - alpha


### PR DESCRIPTION
Follow up to #186, replaces a missed reference to `master`