### PR TITLE
config: configure semantic release to work with new default branch

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,2 +1,0 @@
-singleQuote: true
-trailingComma: 'all'

--- a/package.json
+++ b/package.json
@@ -80,6 +80,12 @@
     "yarn-run-all": "3.1.1"
   },
   "release": {
+    "branches": [
+      "main",
+      { "name": "next", "prerelease": "rc" },
+      { "name": "beta", "prerelease": true },
+      { "name": "alpha", "prerelease": true }
+    ],
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",


### PR DESCRIPTION
Semantic-release wasn't happy that we removed the master branch so I configured it to use the main branch instead.