### PR TITLE
chore: revert dep update that broke build

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,10 +73,10 @@
     "rollup-plugin-babel": "4.4.0",
     "rollup-plugin-vue": "5.1.9",
     "typescript": "4.0.2",
-    "vue": "2.6.12",
+    "vue": "2.6.11",
     "vue-class-component": "7.2.5",
     "vue-property-decorator": "9.0.0",
-    "vue-template-compiler": "2.6.12",
+    "vue-template-compiler": "2.6.11",
     "yarn-run-all": "3.1.1"
   },
   "release": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12566,10 +12566,10 @@ vue-style-loader@^4.1.0, vue-style-loader@^4.1.2:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
 
-vue-template-compiler@2.6.12:
-  version "2.6.12"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.12.tgz#947ed7196744c8a5285ebe1233fe960437fcc57e"
-  integrity sha512-OzzZ52zS41YUbkCBfdXShQTe69j1gQDZ9HIX8miuC9C3rBCk9wIRjLiZZLrmX9V+Ftq/YEyv1JaVr5Y/hNtByg==
+vue-template-compiler@2.6.11:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.11.tgz#c04704ef8f498b153130018993e56309d4698080"
+  integrity sha512-KIq15bvQDrcCjpGjrAhx4mUlyyHfdmTaoNfeoATHLAiWB+MU3cx4lOzMwrnUh9cCxy0Lt1T11hAFY6TQgroUAA==
   dependencies:
     de-indent "^1.0.2"
     he "^1.1.0"
@@ -12579,12 +12579,7 @@ vue-template-es2015-compiler@^1.6.0, vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
-vue@2.6.12:
-  version "2.6.12"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.12.tgz#f5ebd4fa6bd2869403e29a896aed4904456c9123"
-  integrity sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==
-
-vue@^2.6.10:
+vue@2.6.11, vue@^2.6.10:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.11.tgz#76594d877d4b12234406e84e35275c6d514125c5"
   integrity sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==


### PR DESCRIPTION
ssia.

Renovate waits for all status checks before merging. Unfortunately, in this case, the travis status check didn't register (probably related to the issues we've had with Travis recently), so Renovate merged the PR even though the travis build would eventually fail. For now I've added the travis status check as a required check, and upgraded imgix-git-robot to admin so that semantic release will still work (see #5 [here](https://paper.dropbox.com/doc/Continuous-Delivery-for-SDK-libraries--A6TRzsS8aEVdXUkzURFIpimsAg-cwvR6vErtYImIbQaJHBkX#:uid=478409582922117316091303&h2=Installing-semantic-release)) for more info.