### PR TITLE
ci: update supported node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 
 node_js:
-  - 13
+  - stable
+  - lts/*
 
 addons:
   apt:


### PR DESCRIPTION
Tests against [currently supported](https://nodejs.org/en/about/releases/) LTS and stable node versions.