### PR TITLE
config: update auto-release workflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,6 @@ script:
   - yarn test:unit
   - yarn test:e2e --headless
 
-branches:
-  only:
-    - main
-    - next
-    - beta
-    - alpha
-
 deploy:
   provider: script
   skip_cleanup: true

--- a/package.json
+++ b/package.json
@@ -90,8 +90,70 @@
       { "name": "alpha", "prerelease": true }
     ],
     "plugins": [
-      "@semantic-release/commit-analyzer",
-      "@semantic-release/release-notes-generator",
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "releaseRules": [
+            {
+              "type": "docs",
+              "release": "patch"
+            },
+            {
+              "type": "deps",
+              "scope": "deps",
+              "release": "patch"
+            }
+          ]
+        }
+      ],
+      [
+        "@semantic-release/release-notes-generator",
+        {
+          "preset": "conventionalcommits",
+          "writerOpts": {
+            "types": [
+              {
+                "type": "feat",
+                "section": "Features"
+              },
+              {
+                "type": "fix",
+                "section": "Bug Fixes"
+              },
+              {
+                "type": "docs",
+                "section": "Documentation",
+                "hidden": false
+              },
+              {
+                "type": "deps",
+                "section": "Dependency Updates",
+                "hidden": false
+              },
+              {
+                "type": "chore",
+                "hidden": true
+              },
+              {
+                "type": "style",
+                "hidden": true
+              },
+              {
+                "type": "refactor",
+                "hidden": true
+              },
+              {
+                "type": "perf",
+                "hidden": true
+              },
+              {
+                "type": "test",
+                "hidden": true
+              }
+            ]
+          }
+        }
+      ],
       [
         "@google/semantic-release-replace-plugin",
         {

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,3 @@
 {
-  "extends": ["config:js-lib"],
-  "automerge": false,
-  "patch": {
-    "automerge": true
-  },
-  "devDependencies": {
-    "automerge": true
-  }
+  "extends": ["github>imgix/renovate-config"]
 }


### PR DESCRIPTION
This PR updates the auto-release/dependency workflow to adopt imgix's shared Renovate config and changes needed due this adoption. Specifically:

- Renovate's config is based on the shared imgix configuration
- Travis no longer builds PRs, and instead builds all branches
- Semantic release will release dependency (excl. dev dependency) updates, as well as doc PRs (previously it didn't release these)