### PR TITLE
chore: explicitly export & import type IVueImgixClient

### DIFF
--- a/src/plugins/vue-imgix/types.ts
+++ b/src/plugins/vue-imgix/types.ts
@@ -30,10 +30,10 @@ export type IBuildSrcSet = (
   options?: IBuildSrcSetOptions,
 ) => string;
 
-export interface IVueImgixClient {
+export type IVueImgixClient = {
   buildUrlObject: IBuildUrlObject;
   buildUrl: IBuildUrl;
   buildSrcSet: IBuildSrcSet;
-}
+};
 
 export type IVueUseImgixOptions = IImgixClientOptions;

--- a/src/plugins/vue-imgix/vue-imgix.ts
+++ b/src/plugins/vue-imgix/vue-imgix.ts
@@ -9,8 +9,8 @@ import {
   IBuildUrlObjectResult,
   IImgixClientOptions,
   IImgixParams,
-  IVueImgixClient,
 } from './types';
+import type { IVueImgixClient } from './types';
 
 // Do not change this
 const VERSION = '2.8.3';


### PR DESCRIPTION
## Description

This PR fixes a typescript error where `IVueImgixClient` was not being exported by `./types`.

Tested locally with `yarn test` and produced no errors.

## Steps to test

Run `yarn serve` on `main` and see the error. Run `yarn serve` on this branch and see no error.