### PR TITLE
feat: add full url static methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ To render a simple image that will display an image based on the browser's DPR a
 <ix-img src="examples/pione.jpg" sizes="100vw" />
 ```
 
+To render an image with a source URL different than the one setup in the plugin configuration, just set the `src` attribute to the full URL path of the image, like so:
+
+```html
+<ix-img src="https://sdk-test.imgix.net/amsterdam.jpg" sizes="100vw" />
+```
+
 [![Edit festive-mclean-6risg](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/festive-mclean-6risg?fontsize=14&hidenavigation=1&theme=dark)
 
 **Please note:** `100vw` is an appropriate `sizes` value for a full-bleed image. If your image is not full-bleed, you should use a different value for `sizes`. [Eric Portis' "Srcset and sizes"](https://ericportis.com/posts/2014/srcset-sizes/) article goes into depth on how to use the `sizes` attribute. An important note here is that **sizes cannot be a percentage based value**, and must be in terms of vw, or a fixed size (px, em, rem, etc)

--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -25,6 +25,7 @@ export default [
       }),
       buble({
         objectAssign: true,
+        transforms: { dangerousForOf: true },
       }),
       commonjs(),
     ],
@@ -47,6 +48,7 @@ export default [
       }),
       buble({
         objectAssign: true,
+        transforms: { dangerousForOf: true },
       }),
       commonjs(),
     ],
@@ -75,6 +77,7 @@ export default [
       }),
       buble({
         objectAssign: true,
+        transforms: { dangerousForOf: true },
       }),
       commonjs(),
     ],

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prepublishOnly": "run-s build"
   },
   "dependencies": {
-    "@imgix/js-core": "^3.1.3"
+    "@imgix/js-core": "^3.3.0"
   },
   "devDependencies": {
     "@google/semantic-release-replace-plugin": "1.0.2",

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,8 @@
   <div id="app">
     <h1>Simple Usage</h1>
     <simple />
+    <h1>Static Usage</h1>
+    <partial />
 
     <h1>Advanced Usage</h1>
     <advanced-api />
@@ -20,6 +22,7 @@ import advancedBuildUrl from './components/advanced/buildUrl';
 import advancedBuildSrcSet from './components/advanced/buildSrcSet';
 import advancedApi from './components/advanced/advanced';
 import simple from './components/simple/simple';
+import partial from './components/simple/static-api';
 
 export default {
   name: 'App',
@@ -30,6 +33,7 @@ export default {
     advancedBuildSrcSet,
     advancedApi,
     simple,
+    partial,
   },
 
   computed: {},

--- a/src/components/simple/static-api.vue
+++ b/src/components/simple/static-api.vue
@@ -1,0 +1,26 @@
+<template>
+  <div>
+    <h2>2-step URL API Example</h2>
+    <ix-img
+      src="/examples/pione.jpg"
+      width="100"
+      data-testid="2-step-api"
+    />
+    <ix-img
+      src="https://assets.imgix.net/examples/pione.jpg"
+      width="100"
+      data-testid="2-step-api"
+    />
+    <ix-img
+      src="https://sdk-test.imgix.net/amsterdam.jpg"
+      width="100"
+      data-testid="2-step-api"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  name: '2-step-api',
+};
+</script>

--- a/src/components/simple/static-api.vue
+++ b/src/components/simple/static-api.vue
@@ -1,11 +1,7 @@
 <template>
   <div>
     <h2>2-step URL API Example</h2>
-    <ix-img
-      src="/examples/pione.jpg"
-      width="100"
-      data-testid="2-step-api"
-    />
+    <ix-img src="/examples/pione.jpg" width="100" data-testid="2-step-api" />
     <ix-img
       src="https://assets.imgix.net/examples/pione.jpg"
       width="100"

--- a/src/plugins/vue-imgix/types.ts
+++ b/src/plugins/vue-imgix/types.ts
@@ -33,7 +33,9 @@ export type IBuildSrcSet = (
 export type IVueImgixClient = {
   buildUrlObject: IBuildUrlObject;
   buildUrl: IBuildUrl;
+  _buildUrl: IBuildUrl;
   buildSrcSet: IBuildSrcSet;
+  _buildSrcSet: IBuildSrcSet;
 };
 
 export type IVueUseImgixOptions = IImgixClientOptions;

--- a/src/plugins/vue-imgix/vue-imgix.ts
+++ b/src/plugins/vue-imgix/vue-imgix.ts
@@ -57,8 +57,8 @@ class VueImgixClient implements IVueImgixClient {
       ...sharedOptions // Right now this is only passed to buildSrcSet, but in the future it might be passed to buildUrl
     } = options;
 
-    const src = this.buildUrl(url, ixParams);
-    const srcset = this.buildSrcSet(url, ixParams, {
+    const src = this._buildUrl(url, ixParams);
+    const srcset = this._buildSrcSet(url, ixParams, {
       widths,
       widthTolerance,
       minWidth,
@@ -73,12 +73,48 @@ class VueImgixClient implements IVueImgixClient {
     return this.client.buildURL(url, this.buildIxParams(ixParams));
   };
 
+  _buildUrl = (url: string, ixParams?: IImgixParams): string => {
+    // if 2-step URL
+    if (!url.includes('://')) {
+      return this.client.buildURL(url, this.buildIxParams(ixParams));
+    } else {
+      return ImgixClient._buildURL({ url, params: this.buildIxParams(ixParams) });
+    }
+
+  };
+
   buildSrcSet = (
     url: string,
     ixParams?: IImgixParams,
     options?: IBuildSrcSetOptions,
   ): string => {
-    return this.client.buildSrcSet(url, this.buildIxParams(ixParams), options);
+    return this.client.buildSrcSet(
+      url,
+      this.buildIxParams(ixParams),
+      options,
+    );
+  };
+
+  _buildSrcSet = (
+    url: string,
+    ixParams?: IImgixParams,
+    options?: IBuildSrcSetOptions,
+  ): string => {
+    // if 2-step URL
+    // eslint-disable-next-line
+    if (!url.includes('://')) {
+      return this.client.buildSrcSet(
+        url,
+        this.buildIxParams(ixParams),
+        options,
+      );
+    } else {
+      return ImgixClient._buildSrcSet({
+        url,
+        params: this.buildIxParams(ixParams),
+        options,
+      });
+    }
   };
 }
 
@@ -112,12 +148,12 @@ export const buildUrlObject: IBuildUrlObject = (...args) => {
 
 export const buildUrl: IBuildUrl = (...args) => {
   const client = ensureVueImgixClientSingleton();
-  return client.buildUrl(...args);
+  return client._buildUrl(...args);
 };
 
 export const buildSrcSet: IBuildSrcSet = (...args) => {
   const client = ensureVueImgixClientSingleton();
-  return client.buildSrcSet(...args);
+  return client._buildSrcSet(...args);
 };
 
 export { IVueImgixClient, IxImg };

--- a/src/plugins/vue-imgix/vue-imgix.ts
+++ b/src/plugins/vue-imgix/vue-imgix.ts
@@ -80,7 +80,6 @@ class VueImgixClient implements IVueImgixClient {
     } else {
       return ImgixClient._buildURL(url, this.buildIxParams(ixParams));
     }
-
   };
 
   buildSrcSet = (
@@ -88,11 +87,7 @@ class VueImgixClient implements IVueImgixClient {
     ixParams?: IImgixParams,
     options?: IBuildSrcSetOptions,
   ): string => {
-    return this.client.buildSrcSet(
-      url,
-      this.buildIxParams(ixParams),
-      options,
-    );
+    return this.client.buildSrcSet(url, this.buildIxParams(ixParams), options);
   };
 
   _buildSrcSet = (

--- a/src/plugins/vue-imgix/vue-imgix.ts
+++ b/src/plugins/vue-imgix/vue-imgix.ts
@@ -78,7 +78,7 @@ class VueImgixClient implements IVueImgixClient {
     if (!url.includes('://')) {
       return this.client.buildURL(url, this.buildIxParams(ixParams));
     } else {
-      return ImgixClient._buildURL({ url, params: this.buildIxParams(ixParams) });
+      return ImgixClient._buildURL(url, this.buildIxParams(ixParams));
     }
 
   };
@@ -109,11 +109,11 @@ class VueImgixClient implements IVueImgixClient {
         options,
       );
     } else {
-      return ImgixClient._buildSrcSet({
+      return ImgixClient._buildSrcSet(
         url,
-        params: this.buildIxParams(ixParams),
+        this.buildIxParams(ixParams),
         options,
-      });
+      );
     }
   };
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  chainWebpack: (config) => config.resolve.symlinks(false),
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1300,13 +1300,14 @@
   dependencies:
     "@hapi/hoek" "^8.3.0"
 
-"@imgix/js-core@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@imgix/js-core/-/js-core-3.1.3.tgz#9c26366f84f59e6c238c41455f45aacdf04862b7"
-  integrity sha512-7HUIFy4dq9wLSJURgPhglSni50rt3af4cAyBip14koR5oPIGgTGs0W41aQZc5gyCesh7jZaSjm4VxiwqS7gszw==
+"@imgix/js-core@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@imgix/js-core/-/js-core-3.3.0.tgz#a81348de76a6dcd70333757566f2c3b701a0e719"
+  integrity sha512-tQQDOho//WqxoGRgG2QvkMPxKLS1Lm0LDydpPsRvPjUeBCXJju+2zfG4BHeXbgxmxc46pCgeoqhP5U7h3HAy+w==
   dependencies:
-    js-base64 "~2.6.0"
+    js-base64 "~3.6.0"
     md5 "^2.2.1"
+    ufo "^0.7.5"
 
 "@intervolga/optimize-cssnano-plugin@^1.0.5":
   version "1.0.6"
@@ -7797,10 +7798,10 @@ js-base64@^2.1.9:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.2.tgz#313b6274dda718f714d00b3330bbae6e38e90209"
   integrity sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ==
 
-js-base64@~2.6.0:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
-  integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
+js-base64@~3.6.0:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.6.1.tgz#555aae398b74694b4037af1f8a5a6209d170efbe"
+  integrity sha512-Frdq2+tRRGLQUIQOgsIGSCd1VePCS2fsddTG5dTCqR0JHgltXWfsxnY0gIXPoMeRmdom6Oyq+UMOFg5suduOjQ==
 
 js-beautify@^1.6.12, js-beautify@^1.6.14:
   version "1.11.0"
@@ -12204,6 +12205,11 @@ typescript@4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
   integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
+
+ufo@^0.7.5:
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-0.7.7.tgz#0062f9e5e790819b0fb23ca24d7c63a4011c036a"
+  integrity sha512-N25aY3HBkJBnahm+2l4JRBBrX5I+JPakF/tDHYDTjd3wUR7iFLdyiPhj8mBwBz21v728BKwM9L9tgBfCntgdlw==
 
 uglify-js@3.4.x:
   version "3.4.10"


### PR DESCRIPTION
- This PR adds static `_buildURL` and `_buildSrcSet` methods to the `VueImgixClient`.
- It assumes these static methods have been defined on the `@imgix/js-core` dependency [pending].

## Future work
This PR needs to be updated to include better logic on detecting full path, or 1-step, URLs. As it stands, we only check for the `://` delimiter. This won't be sufficient for some edge cases.