### PR TITLE
chore: use Node v16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - stable
+  - 16
   - lts/*
 
 addons:


### PR DESCRIPTION
This fixes a build issue between Node v17 and Webpack.

More info: https://github.com/webpack/webpack/issues/14532
