### PR TITLE
chore: update slot syntax to vue 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: node_js
 
-node_js:
-  - stable
-  - lts/*
+jobs:
+  include:
+  - node: lts/*
+  - node: stable
+    env: NODE_OPTIONS=--openssl-legacy-provider
 
 addons:
   apt:

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build:test-app": "vue-cli-service build",
     "test": "run-s test:unit test:e2e",
     "test:unit": "vue-cli-service test:unit",
-    "test:e2e": "vue-cli-service test:e2e",
+    "test:e2e": "vue-cli-service test:e2e --browser chrome",
     "lint": "vue-cli-service lint",
     "lint:ci": "vue-cli-service lint --no-fix --max-warnings 0",
     "prepublishOnly": "run-s build",

--- a/src/components/simple/ix-picture.vue
+++ b/src/components/simple/ix-picture.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>
+    <h2>Picture</h2>
+    <div data-testid="simple-picture">
+      <ix-picture>
+        <ix-source src="blog/unsplash-kiss.jpg" />
+        <ix-img src="blog/unsplash-kiss.jpg" />
+      </ix-picture>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ix-picture-simple',
+};
+</script>

--- a/src/plugins/vue-imgix/ix-picture.tsx
+++ b/src/plugins/vue-imgix/ix-picture.tsx
@@ -1,5 +1,5 @@
-import { ensureVueImgixClientSingleton } from './vue-imgix';
 import { defineComponent, h } from 'vue';
+import { ensureVueImgixClientSingleton } from './vue-imgix';
 
 const IxPictureProps = defineComponent({
   props: {},
@@ -7,9 +7,11 @@ const IxPictureProps = defineComponent({
 
 export const IxPicture = defineComponent({
   mixins: [IxPictureProps],
-  render() {
+  setup(_, { slots }) {
     ensureVueImgixClientSingleton();
-
-    return h('picture', this.$slots.default);
+    const defaultSlots = slots && slots.default && slots.default();
+    return () => {
+      return h('picture', defaultSlots);
+    };
   },
 });

--- a/tests/unit/imgix-component.spec.ts
+++ b/tests/unit/imgix-component.spec.ts
@@ -8,7 +8,7 @@ import { createApp } from 'vue';
 import _App from '../../src/App.vue';
 import {
   expectElementToHaveFixedSrcAndSrcSet,
-  expectElementToHaveFluidSrcAndSrcSet
+  expectElementToHaveFluidSrcAndSrcSet,
 } from '../helpers/url-assert';
 /**
  * Why register the plugin and each individual component globally?
@@ -16,7 +16,7 @@ import {
  * It's a limitation with  @vue/test-utils at the moment. The
  * `config.global.plugins` option is supposed to register plugins globally,
  * but it doesn't seem to work when tests are run in parallel.
- * 
+ *
  * The only reliable way to register plugins components globally is to register
  * them individually as `config.global.components` as well as
  * `config.global.plugins`.
@@ -57,7 +57,6 @@ describe('imgix component', () => {
 
     expect(srcAttr).toBeTruthy();
     expect(srcAttr).toMatch(/examples\/pione.jpg/);
-
   });
   it(`the rendered img's srcset should be set correctly`, () => {
     const wrapper = mount(IxImg, {
@@ -67,7 +66,9 @@ describe('imgix component', () => {
       },
     });
 
-    const srcset = wrapper.find('img[data-testid="img-rendering"]').element.getAttribute('srcset');
+    const srcset = wrapper
+      .find('img[data-testid="img-rendering"]')
+      .element.getAttribute('srcset');
 
     expect(srcset).not.toBeFalsy();
     if (!srcset) {
@@ -89,7 +90,7 @@ describe('imgix component', () => {
         ['data-testid']: 'img-rendering',
         imgixParams: {
           crop: 'faces',
-        }
+        },
       },
     });
 
@@ -118,7 +119,8 @@ describe('imgix component', () => {
 
       const el = wrapper.get('img[data-testid="img-rendering"]').html();
       // create HTMLElement from el
-      const img = new DOMParser().parseFromString(el, 'text/html').body.firstChild as HTMLImageElement;
+      const img = new DOMParser().parseFromString(el, 'text/html').body
+        .firstChild as HTMLImageElement;
       expectElementToHaveFluidSrcAndSrcSet(img);
     });
   });
@@ -158,7 +160,7 @@ describe('imgix component', () => {
 
       const srcAttr = img.getAttribute('src');
       const srcsetAttr = img.getAttribute('srcset');
-      
+
       expectElementToHaveFixedSrcAndSrcSet(img, 100);
       expect(srcAttr).toBeTruthy();
       expect(srcsetAttr).toBeTruthy();
@@ -178,7 +180,7 @@ describe('imgix component', () => {
       const el = wrapper.get('img[data-testid="img-rendering"]').html();
       const img = new DOMParser().parseFromString(el, 'text/html').body
         .firstChild as HTMLImageElement;
-      
+
       const widthAttr = img.getAttribute('width');
 
       expect(widthAttr).toBeTruthy();
@@ -196,7 +198,7 @@ describe('imgix component', () => {
       const el = wrapper.get('img[data-testid="img-rendering"]').html();
       const img = new DOMParser().parseFromString(el, 'text/html').body
         .firstChild as HTMLImageElement;
-      
+
       const heightAttr = img.getAttribute('height');
 
       expect(heightAttr).toBeTruthy();
@@ -208,20 +210,20 @@ describe('imgix component', () => {
     const ATTRIBUTES = ['src', 'srcset'];
     ATTRIBUTES.forEach((attribute) => {
       it(`${attribute} can be configured to use data-${attribute}`, () => {
-      const wrapper = mount(IxImg, {
-        props: {
-          ['data-testid']: 'img-rendering',
-          src: 'examples/pione.jpg',
-          attributeConfig: {
-            [attribute]: `data-${attribute}`,
+        const wrapper = mount(IxImg, {
+          props: {
+            ['data-testid']: 'img-rendering',
+            src: 'examples/pione.jpg',
+            attributeConfig: {
+              [attribute]: `data-${attribute}`,
+            },
           },
-        },
-      });
-        
+        });
+
         const el = wrapper.get('img[data-testid="img-rendering"]').html();
         const img = new DOMParser().parseFromString(el, 'text/html').body
           .firstChild as HTMLImageElement;
-        
+
         const customImgAttr = img.getAttribute(`data-${attribute}`);
         const imgAttr = img.getAttribute(attribute);
 

--- a/tests/unit/imgix-component.spec.ts
+++ b/tests/unit/imgix-component.spec.ts
@@ -10,6 +10,17 @@ import {
   expectElementToHaveFixedSrcAndSrcSet,
   expectElementToHaveFluidSrcAndSrcSet
 } from '../helpers/url-assert';
+/**
+ * Why register the plugin and each individual component globally?
+ *
+ * It's a limitation with  @vue/test-utils at the moment. The
+ * `config.global.plugins` option is supposed to register plugins globally,
+ * but it doesn't seem to work when tests are run in parallel.
+ * 
+ * The only reliable way to register plugins components globally is to register
+ * them individually as `config.global.components` as well as
+ * `config.global.plugins`.
+ */
 config.global.plugins = [[VueImgix, { domain: 'assets.imgix.net' }]];
 config.global.components = {
   IxImg,

--- a/tests/unit/imgix-component.spec.ts
+++ b/tests/unit/imgix-component.spec.ts
@@ -1,21 +1,26 @@
-import { createApp } from 'vue';
-import VueImgix, { IxImg } from '@/plugins/vue-imgix';
+import { IxImg } from '@/plugins/vue-imgix';
+import VueImgix from '@/plugins/vue-imgix/index';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/vue';
+import { createApp } from 'vue';
 import _App from '../../src/App.vue';
 import {
   expectElementToHaveFixedSrcAndSrcSet,
   expectElementToHaveFluidSrcAndSrcSet,
 } from '../helpers/url-assert';
 
-const App = createApp(_App);
+beforeAll(() => {
+  const el = document.createElement('div');
+  el.id = 'app';
+  document.body.appendChild(el);
+  createApp(_App)
+    .use(VueImgix, {
+      domain: 'assets.imgix.net',
+    })
+    .mount('#app');
+});
 
 describe('imgix component', () => {
-  beforeAll(() => {
-    App.use(VueImgix, {
-      domain: 'assets.imgix.net',
-    });
-  });
   it('an img should be rendered', () => {
     render(IxImg, {
       props: {
@@ -185,6 +190,7 @@ describe('imgix component', () => {
     });
   });
   describe('disableVariableQuality', () => {
+    const App = createApp(_App);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let mockImgixClient: any;
     let _IxImg: typeof IxImg;

--- a/tests/unit/imgix-component.spec.ts
+++ b/tests/unit/imgix-component.spec.ts
@@ -33,11 +33,10 @@ describe('imgix component', () => {
     const wrapper = mount(IxImg, {
       props: {
         src: 'examples/pione.jpg',
-        ['data-testid']: 'img-rendering',
       },
     });
 
-    const el = wrapper.find('img[data-testid="img-rendering"]').html();
+    const el = wrapper.find('img').html();
 
     expect(el).toBeTruthy();
   });
@@ -45,11 +44,10 @@ describe('imgix component', () => {
     const wrapper = mount(IxImg, {
       props: {
         src: 'examples/pione.jpg',
-        ['data-testid']: 'img-rendering',
       },
     });
 
-    const img = wrapper.get('img[data-testid="img-rendering"]').element as HTMLImageElement;
+    const img = wrapper.get('img').element as HTMLImageElement;
     const srcAttr = img.getAttribute('src');
 
     expect(srcAttr).toBeTruthy();
@@ -59,12 +57,11 @@ describe('imgix component', () => {
     const wrapper = mount(IxImg, {
       props: {
         src: 'examples/pione.jpg',
-        ['data-testid']: 'img-rendering',
       },
     });
 
     const srcset = wrapper
-      .find('img[data-testid="img-rendering"]')
+      .find('img')
       .element.getAttribute('srcset');
 
     expect(srcset).not.toBeFalsy();
@@ -84,14 +81,13 @@ describe('imgix component', () => {
     const wrapper = mount(IxImg, {
       props: {
         src: 'examples/pione.jpg',
-        ['data-testid']: 'img-rendering',
         imgixParams: {
           crop: 'faces',
         },
       },
     });
 
-    const img = wrapper.find('img[data-testid="img-rendering"]').element as HTMLElement;
+    const img = wrapper.find('img').element as HTMLElement;
     const srcAttr = img.getAttribute('src');
     const srcsetAttr = img.getAttribute('srcset');
 
@@ -106,11 +102,10 @@ describe('imgix component', () => {
       const wrapper = mount(IxImg, {
         props: {
           src: 'examples/pione.jpg',
-          ['data-testid']: 'img-rendering',
         },
       });
 
-      const img = wrapper.get('img[data-testid="img-rendering"]').element as HTMLElement;
+      const img = wrapper.get('img').element as HTMLElement;
       expectElementToHaveFluidSrcAndSrcSet(img);
     });
   });
@@ -119,7 +114,6 @@ describe('imgix component', () => {
     it('the src and srcset should be in fixed size mode when a width is passed to imgixParams', () => {
       const wrapper = mount(IxImg, {
         props: {
-          ['data-testid']: 'img-rendering',
           src: 'examples/pione.jpg',
           imgixParams: {
             w: 100,
@@ -127,13 +121,12 @@ describe('imgix component', () => {
         },
       });
 
-      const img = wrapper.get('img[data-testid="img-rendering"]').element as HTMLElement;
+      const img = wrapper.get('img').element as HTMLElement;
       expectElementToHaveFixedSrcAndSrcSet(img, 100);
     });
     it('the src and srcset should be in fixed size mode when a fixed prop is passed to the element', () => {
       const wrapper = mount(IxImg, {
         props: {
-          ['data-testid']: 'img-rendering',
           src: 'examples/pione.jpg',
           width: 100,
           height: 150,
@@ -141,7 +134,7 @@ describe('imgix component', () => {
         },
       });
 
-      const img = wrapper.get('img[data-testid="img-rendering"]').element as HTMLElement;
+      const img = wrapper.get('img').element as HTMLElement;
       const srcAttr = img.getAttribute('src');
       const srcsetAttr = img.getAttribute('srcset');
 
@@ -155,13 +148,12 @@ describe('imgix component', () => {
     it('a width attribute should be passed through to the underlying component', () => {
       const wrapper = mount(IxImg, {
         props: {
-          ['data-testid']: 'img-rendering',
           src: 'examples/pione.jpg',
           width: 100,
         },
       });
 
-      const img = wrapper.get('img[data-testid="img-rendering"]').element as HTMLElement;
+      const img = wrapper.get('img').element as HTMLElement;
       const widthAttr = img.getAttribute('width');
 
       expect(widthAttr).toBeTruthy();
@@ -170,13 +162,12 @@ describe('imgix component', () => {
     it('a height attribute should be passed through to the underlying component', () => {
       const wrapper = mount(IxImg, {
         props: {
-          ['data-testid']: 'img-rendering',
           src: 'examples/pione.jpg',
           height: 100,
         },
       });
 
-      const img = wrapper.get('img[data-testid="img-rendering"]').element as HTMLElement;
+      const img = wrapper.get('img').element as HTMLElement;
 
       const heightAttr = img.getAttribute('height');
 
@@ -191,7 +182,6 @@ describe('imgix component', () => {
       it(`${attribute} can be configured to use data-${attribute}`, () => {
         const wrapper = mount(IxImg, {
           props: {
-            ['data-testid']: 'img-rendering',
             src: 'examples/pione.jpg',
             attributeConfig: {
               [attribute]: `data-${attribute}`,
@@ -199,7 +189,7 @@ describe('imgix component', () => {
           },
         });
 
-        const img = wrapper.get('img[data-testid="img-rendering"]').element as HTMLElement;
+        const img = wrapper.get('img').element as HTMLElement;
         const customImgAttr = img.getAttribute(`data-${attribute}`);
         const imgAttr = img.getAttribute(attribute);
 

--- a/tests/unit/imgix-component.spec.ts
+++ b/tests/unit/imgix-component.spec.ts
@@ -231,6 +231,7 @@ describe('imgix component', () => {
       });
     });
   });
+  // TODO: remove instances of createApp and `render` from test.
   describe('disableVariableQuality', () => {
     const App = createApp(_App);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tests/unit/imgix-component.spec.ts
+++ b/tests/unit/imgix-component.spec.ts
@@ -8,7 +8,7 @@ import { createApp } from 'vue';
 import _App from '../../src/App.vue';
 import {
   expectElementToHaveFixedSrcAndSrcSet,
-  expectElementToHaveFluidSrcAndSrcSet,
+  expectElementToHaveFluidSrcAndSrcSet
 } from '../helpers/url-assert';
 /**
  * Why register the plugin and each individual component globally?
@@ -49,10 +49,7 @@ describe('imgix component', () => {
       },
     });
 
-    const el = wrapper.get('img[data-testid="img-rendering"]').html();
-    // create HTMLElement from el
-    const img = new DOMParser().parseFromString(el, 'text/html').body
-      .firstChild as HTMLImageElement;
+    const img = wrapper.get('img[data-testid="img-rendering"]').element as HTMLImageElement;
     const srcAttr = img.getAttribute('src');
 
     expect(srcAttr).toBeTruthy();
@@ -94,11 +91,7 @@ describe('imgix component', () => {
       },
     });
 
-    const el = wrapper.find('img[data-testid="img-rendering"]').html();
-    // create HTMLElement from el
-    const img = new DOMParser().parseFromString(el, 'text/html').body
-      .firstChild as HTMLImageElement;
-
+    const img = wrapper.find('img[data-testid="img-rendering"]').element as HTMLElement;
     const srcAttr = img.getAttribute('src');
     const srcsetAttr = img.getAttribute('srcset');
 
@@ -117,10 +110,7 @@ describe('imgix component', () => {
         },
       });
 
-      const el = wrapper.get('img[data-testid="img-rendering"]').html();
-      // create HTMLElement from el
-      const img = new DOMParser().parseFromString(el, 'text/html').body
-        .firstChild as HTMLImageElement;
+      const img = wrapper.get('img[data-testid="img-rendering"]').element as HTMLElement;
       expectElementToHaveFluidSrcAndSrcSet(img);
     });
   });
@@ -137,10 +127,7 @@ describe('imgix component', () => {
         },
       });
 
-      const el = wrapper.get('img[data-testid="img-rendering"]').html();
-      // create HTMLElement from el
-      const img = new DOMParser().parseFromString(el, 'text/html').body
-        .firstChild as HTMLImageElement;
+      const img = wrapper.get('img[data-testid="img-rendering"]').element as HTMLElement;
       expectElementToHaveFixedSrcAndSrcSet(img, 100);
     });
     it('the src and srcset should be in fixed size mode when a fixed prop is passed to the element', () => {
@@ -154,10 +141,7 @@ describe('imgix component', () => {
         },
       });
 
-      const el = wrapper.get('img[data-testid="img-rendering"]').html();
-      const img = new DOMParser().parseFromString(el, 'text/html').body
-        .firstChild as HTMLImageElement;
-
+      const img = wrapper.get('img[data-testid="img-rendering"]').element as HTMLElement;
       const srcAttr = img.getAttribute('src');
       const srcsetAttr = img.getAttribute('srcset');
 
@@ -177,10 +161,7 @@ describe('imgix component', () => {
         },
       });
 
-      const el = wrapper.get('img[data-testid="img-rendering"]').html();
-      const img = new DOMParser().parseFromString(el, 'text/html').body
-        .firstChild as HTMLImageElement;
-
+      const img = wrapper.get('img[data-testid="img-rendering"]').element as HTMLElement;
       const widthAttr = img.getAttribute('width');
 
       expect(widthAttr).toBeTruthy();
@@ -195,9 +176,7 @@ describe('imgix component', () => {
         },
       });
 
-      const el = wrapper.get('img[data-testid="img-rendering"]').html();
-      const img = new DOMParser().parseFromString(el, 'text/html').body
-        .firstChild as HTMLImageElement;
+      const img = wrapper.get('img[data-testid="img-rendering"]').element as HTMLElement;
 
       const heightAttr = img.getAttribute('height');
 
@@ -220,10 +199,7 @@ describe('imgix component', () => {
           },
         });
 
-        const el = wrapper.get('img[data-testid="img-rendering"]').html();
-        const img = new DOMParser().parseFromString(el, 'text/html').body
-          .firstChild as HTMLImageElement;
-
+        const img = wrapper.get('img[data-testid="img-rendering"]').element as HTMLElement;
         const customImgAttr = img.getAttribute(`data-${attribute}`);
         const imgAttr = img.getAttribute(attribute);
 

--- a/tests/unit/imgix-component.spec.ts
+++ b/tests/unit/imgix-component.spec.ts
@@ -8,7 +8,7 @@ import { createApp } from 'vue';
 import _App from '../../src/App.vue';
 import {
   expectElementToHaveFixedSrcAndSrcSet,
-  expectElementToHaveFluidSrcAndSrcSet
+  expectElementToHaveFluidSrcAndSrcSet,
 } from '../helpers/url-assert';
 /**
  * Why register the plugin and each individual component globally?
@@ -60,9 +60,7 @@ describe('imgix component', () => {
       },
     });
 
-    const srcset = wrapper
-      .find('img')
-      .element.getAttribute('srcset');
+    const srcset = wrapper.find('img').element.getAttribute('srcset');
 
     expect(srcset).not.toBeFalsy();
     if (!srcset) {

--- a/tests/unit/picture-mode.spec.tsx
+++ b/tests/unit/picture-mode.spec.tsx
@@ -22,6 +22,15 @@ describe('Picture Mode', () => {
       expect(picture.element.tagName).toBe('PICTURE');
     });
 
+    it('should render a <source> component as a child', () => {
+      const wrapper = mount(IxPictureSimple, {
+        shallow: false,
+      });
+      const sourceElement = wrapper.find('picture > source');
+      expect(sourceElement.exists()).toBe(true);
+      expect(sourceElement.element.tagName).toBe('SOURCE');
+    });
+
     it('should allow developer to pass an ix-img component as a fallback src', () => {
       const wrapper = mount(IxPictureSimple, {
         shallow: false,
@@ -33,15 +42,6 @@ describe('Picture Mode', () => {
       expect(fallBackSrc).toMatch(/ixlib=vue/);
       expect(fallBackSrcSet).toBeDefined();
       expect(fallBackSrcSet).toMatch(/ixlib/);
-    });
-
-    it('should render a <source> component as a child', () => {
-      const wrapper = mount(IxPictureSimple, {
-        shallow: false,
-      });
-      const sourceElement = wrapper.find('picture > source');
-      expect(sourceElement.exists()).toBe(true);
-      expect(sourceElement.element.tagName).toBe('SOURCE');
     });
 
     it('should have a srcset attribute', () => {


### PR DESCRIPTION
This PR updates the `slot` syntax to match the vue 3 [composition API](https://v3.vuejs.org/guide/composition-api-setup.html#context) usage in the `setup()` function.

This PR also updates the test specs to remove as much use of `@testing-library/vue` usage as possible. That library isn't quite ready for Vue 3 yet and was blocking our migration efforts. It's been replaced by more direct usage of `@vue/test-utils`.

## Before this PR
- `ix-picture` component was still using Vue 2 `this.$slots.defaults` syntax. This lead to rendering issues and even App crashes
- The test suite was still relying on `@test-utils/vue` rc.
- CI tests were failing due to `unsupported envelope routine` errors
- CI tests were failing due to Electron issues with headless test running

## After this PR
- `ix-picture` component now uses the composition API `setup()` function to access `context.slots.defaults`, fixing rendering issues.
- The test now almost exclusively use `@vue/test-utils`.
- CI now passes thanks to `openssl-legacy-provider` flag.
- CI tests now are able to run since headless browser defaulted to Chrome