### PR TITLE
feat: create build URL and srcset methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: node_js
 
-jobs:
-  include:
-  - node: lts/*
-  - node: stable
-    env: NODE_OPTIONS=--openssl-legacy-provider
-
+node_js:
+  - 16
+  - lts/*
 addons:
   apt:
     packages:

--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ To render a simple image that will display an image based on the browser's DPR a
 <ix-img src="examples/pione.jpg" sizes="100vw" />
 ```
 
+To render an image with a source URL different than the one setup in the plugin configuration, just set the `src` attribute to the absolute URL path of the image, like so:
+
+```html
+<ix-img src="https://sdk-test.imgix.net/amsterdam.jpg" sizes="100vw" />
+```
+
 [![Edit festive-mclean-6risg](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/festive-mclean-6risg?fontsize=14&hidenavigation=1&theme=dark)
 
 **Please note:** `100vw` is an appropriate `sizes` value for a full-bleed image. If your image is not full-bleed, you should use a different value for `sizes`. [Eric Portis' "Srcset and sizes"](https://ericportis.com/posts/2014/srcset-sizes/) article goes into depth on how to use the `sizes` attribute. An important note here is that **sizes cannot be a percentage based value**, and must be in terms of vw, or a fixed size (px, em, rem, etc)

--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -25,6 +25,7 @@ export default [
       }),
       buble({
         objectAssign: true,
+        transforms: { dangerousForOf: true },
       }),
       commonjs(),
     ],
@@ -47,6 +48,7 @@ export default [
       }),
       buble({
         objectAssign: true,
+        transforms: { dangerousForOf: true },
       }),
       commonjs(),
     ],
@@ -75,6 +77,7 @@ export default [
       }),
       buble({
         objectAssign: true,
+        transforms: { dangerousForOf: true },
       }),
       commonjs(),
     ],

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "release:dryRun": "npx node-env-run --exec 'npx semantic-release --dryRun'"
   },
   "dependencies": {
-    "@imgix/js-core": "^3.1.3"
+    "@imgix/js-core": "^3.6.0-rc.1"
   },
   "devDependencies": {
     "@babel/core": "^7.6.14",

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,8 @@
   <div id="app">
     <h1>Simple Usage</h1>
     <simple />
+    <h1>Static Usage</h1>
+    <partial />
 
     <h1>Advanced Usage</h1>
     <advanced-api />
@@ -20,6 +22,7 @@ import advancedBuildUrl from './components/advanced/buildUrl';
 import advancedBuildSrcSet from './components/advanced/buildSrcSet';
 import advancedApi from './components/advanced/advanced';
 import simple from './components/simple/simple';
+import partial from './components/simple/static-api';
 
 export default {
   name: 'App',
@@ -30,6 +33,7 @@ export default {
     advancedBuildSrcSet,
     advancedApi,
     simple,
+    partial,
   },
 
   computed: {},

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,7 @@
     <h1>Simple Usage</h1>
     <simple />
     <h1>Static Usage</h1>
-    <partial />
+    <static-api />
 
     <h1>Advanced Usage</h1>
     <advanced-api />
@@ -22,7 +22,7 @@ import advancedBuildUrl from './components/advanced/buildUrl';
 import advancedBuildSrcSet from './components/advanced/buildSrcSet';
 import advancedApi from './components/advanced/advanced';
 import simple from './components/simple/simple';
-import partial from './components/simple/static-api';
+import staticApi from './components/simple/static-api';
 
 export default {
   name: 'App',
@@ -33,7 +33,7 @@ export default {
     advancedBuildSrcSet,
     advancedApi,
     simple,
-    partial,
+    staticApi,
   },
 
   computed: {},

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,8 @@
     <advanced-build-url />
     <h2>buildSrcSet</h2>
     <advanced-build-src-set />
+    <h2>_buildSrcSet</h2>
+    <static-build-src-set />
   </div>
 </template>
 
@@ -20,6 +22,7 @@
 import advancedBuildUrlObject from './components/advanced/buildUrlObject';
 import advancedBuildUrl from './components/advanced/buildUrl';
 import advancedBuildSrcSet from './components/advanced/buildSrcSet';
+import staticBuildSrcSet from './components/advanced/_buildSrcSet';
 import advancedApi from './components/advanced/advanced';
 import simple from './components/simple/simple';
 import staticApi from './components/simple/static-api';
@@ -31,6 +34,7 @@ export default {
     advancedBuildUrlObject,
     advancedBuildUrl,
     advancedBuildSrcSet,
+    staticBuildSrcSet,
     advancedApi,
     simple,
     staticApi,

--- a/src/components/advanced/_buildSrcSet.vue
+++ b/src/components/advanced/_buildSrcSet.vue
@@ -1,0 +1,27 @@
+<template>
+  <img
+    :src="advancedSrc"
+    :srcset="advancedSrcSet"
+    data-testid="static-build-src-set"
+  />
+</template>
+
+<script>
+import { buildUrl, buildSrcSet } from '@/plugins/vue-imgix';
+
+// NB: Make sure initVueImgix has been called before this code runs
+export default {
+  name: 'static-build-src-set',
+
+  computed: {
+    advancedSrc: () =>
+      buildUrl('https://sdk-test.imgix.net/amsterdam.jpg', {
+        auto: 'format',
+      }),
+    advancedSrcSet: () =>
+      buildSrcSet('https://sdk-test.imgix.net/amsterdam.jpg', {
+        auto: 'format',
+      }),
+  },
+};
+</script>

--- a/src/components/simple/static-api.vue
+++ b/src/components/simple/static-api.vue
@@ -1,0 +1,26 @@
+<template>
+  <div>
+    <h2>2-step URL API Example</h2>
+    <ix-img
+      src="/examples/pione.jpg"
+      width="100"
+      data-testid="2-step-api"
+    />
+    <ix-img
+      src="https://assets.imgix.net/examples/pione.jpg"
+      width="100"
+      data-testid="2-step-api"
+    />
+    <ix-img
+      src="https://sdk-test.imgix.net/amsterdam.jpg"
+      width="100"
+      data-testid="2-step-api"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  name: '2-step-api',
+};
+</script>

--- a/src/components/simple/static-api.vue
+++ b/src/components/simple/static-api.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <h2>Absolute URL Static API Example</h2>
-    <!–– partial URL gets domain from client -->
+    <!-- partial URL gets domain from client -->
     <ix-img
       src="/examples/pione.jpg"
       width="100"

--- a/src/components/simple/static-api.vue
+++ b/src/components/simple/static-api.vue
@@ -1,26 +1,23 @@
 <template>
   <div>
-    <h2>2-step URL API Example</h2>
+    <h2>Absolute URL Static API Example</h2>
+    // partial URL gets domain from client
     <ix-img
       src="/examples/pione.jpg"
       width="100"
-      data-testid="2-step-api"
+      data-testid="static-api-relative"
     />
-    <ix-img
-      src="https://assets.imgix.net/examples/pione.jpg"
-      width="100"
-      data-testid="2-step-api"
-    />
+    // absolute URL domain does not get overridden
     <ix-img
       src="https://sdk-test.imgix.net/amsterdam.jpg"
       width="100"
-      data-testid="2-step-api"
+      data-testid="static-api-absolute"
     />
   </div>
 </template>
 
 <script>
 export default {
-  name: '2-step-api',
+  name: 'static-api',
 };
 </script>

--- a/src/components/simple/static-api.vue
+++ b/src/components/simple/static-api.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
     <h2>Absolute URL Static API Example</h2>
-    // partial URL gets domain from client
+    <!–– partial URL gets domain from client -->
     <ix-img
       src="/examples/pione.jpg"
       width="100"
       data-testid="static-api-relative"
     />
-    // absolute URL domain does not get overridden
+    <!-- absolute URL domain does not get overridden -->
     <ix-img
       src="https://sdk-test.imgix.net/amsterdam.jpg"
       width="100"

--- a/src/plugins/vue-imgix/types.ts
+++ b/src/plugins/vue-imgix/types.ts
@@ -33,7 +33,9 @@ export type IBuildSrcSet = (
 export type IVueImgixClient = {
   buildUrlObject: IBuildUrlObject;
   buildUrl: IBuildUrl;
+  _buildUrl: IBuildUrl;
   buildSrcSet: IBuildSrcSet;
+  _buildSrcSet: IBuildSrcSet;
 };
 
 export type IVueUseImgixOptions = IImgixClientOptions;

--- a/src/plugins/vue-imgix/vue-imgix.ts
+++ b/src/plugins/vue-imgix/vue-imgix.ts
@@ -57,8 +57,8 @@ class VueImgixClient implements IVueImgixClient {
       ...sharedOptions // Right now this is only passed to buildSrcSet, but in the future it might be passed to buildUrl
     } = options;
 
-    const src = this.buildUrl(url, ixParams);
-    const srcset = this.buildSrcSet(url, ixParams, {
+    const src = this._buildUrl(url, ixParams);
+    const srcset = this._buildSrcSet(url, ixParams, {
       widths,
       widthTolerance,
       minWidth,
@@ -73,12 +73,48 @@ class VueImgixClient implements IVueImgixClient {
     return this.client.buildURL(url, this.buildIxParams(ixParams));
   };
 
+  _buildUrl = (url: string, ixParams?: IImgixParams): string => {
+    // if 2-step URL
+    if (!url.includes('://')) {
+      return this.client.buildURL(url, this.buildIxParams(ixParams));
+    } else {
+      return ImgixClient._buildURL({ url, params: this.buildIxParams(ixParams) });
+    }
+
+  };
+
   buildSrcSet = (
     url: string,
     ixParams?: IImgixParams,
     options?: IBuildSrcSetOptions,
   ): string => {
-    return this.client.buildSrcSet(url, this.buildIxParams(ixParams), options);
+    return this.client.buildSrcSet(
+      url,
+      this.buildIxParams(ixParams),
+      options,
+    );
+  };
+
+  _buildSrcSet = (
+    url: string,
+    ixParams?: IImgixParams,
+    options?: IBuildSrcSetOptions,
+  ): string => {
+    // if 2-step URL
+    // eslint-disable-next-line
+    if (!url.includes('://')) {
+      return this.client.buildSrcSet(
+        url,
+        this.buildIxParams(ixParams),
+        options,
+      );
+    } else {
+      return ImgixClient._buildSrcSet({
+        url,
+        params: this.buildIxParams(ixParams),
+        options,
+      });
+    }
   };
 }
 
@@ -112,12 +148,12 @@ export const buildUrlObject: IBuildUrlObject = (...args) => {
 
 export const buildUrl: IBuildUrl = (...args) => {
   const client = ensureVueImgixClientSingleton();
-  return client.buildUrl(...args);
+  return client._buildUrl(...args);
 };
 
 export const buildSrcSet: IBuildSrcSet = (...args) => {
   const client = ensureVueImgixClientSingleton();
-  return client.buildSrcSet(...args);
+  return client._buildSrcSet(...args);
 };
 
 export { IVueImgixClient, IxImg };

--- a/src/plugins/vue-imgix/vue-imgix.ts
+++ b/src/plugins/vue-imgix/vue-imgix.ts
@@ -1,5 +1,6 @@
 import ImgixClient from '@imgix/js-core';
 import { IxImg } from './ix-img';
+import type { IVueImgixClient } from './types';
 import {
   IBuildSrcSet,
   IBuildSrcSetOptions,
@@ -8,9 +9,8 @@ import {
   IBuildUrlObjectOptions,
   IBuildUrlObjectResult,
   IImgixClientOptions,
-  IImgixParams,
+  IImgixParams
 } from './types';
-import type { IVueImgixClient } from './types';
 
 // Do not change this
 const VERSION = '3.0.0-rc.1';
@@ -78,7 +78,7 @@ class VueImgixClient implements IVueImgixClient {
     if (!url.includes('://')) {
       return this.client.buildURL(url, this.buildIxParams(ixParams));
     } else {
-      return ImgixClient._buildURL({ url, params: this.buildIxParams(ixParams) });
+      return ImgixClient._buildURL(url, this.buildIxParams(ixParams) );
     }
 
   };
@@ -109,11 +109,11 @@ class VueImgixClient implements IVueImgixClient {
         options,
       );
     } else {
-      return ImgixClient._buildSrcSet({
+      return ImgixClient._buildSrcSet(
         url,
-        params: this.buildIxParams(ixParams),
+        this.buildIxParams(ixParams),
         options,
-      });
+      );
     }
   };
 }

--- a/src/plugins/vue-imgix/vue-imgix.ts
+++ b/src/plugins/vue-imgix/vue-imgix.ts
@@ -9,7 +9,7 @@ import {
   IBuildUrlObjectOptions,
   IBuildUrlObjectResult,
   IImgixClientOptions,
-  IImgixParams
+  IImgixParams,
 } from './types';
 
 // Do not change this
@@ -78,9 +78,8 @@ class VueImgixClient implements IVueImgixClient {
     if (!url.includes('://')) {
       return this.client.buildURL(url, this.buildIxParams(ixParams));
     } else {
-      return ImgixClient._buildURL(url, this.buildIxParams(ixParams) );
+      return ImgixClient._buildURL(url, this.buildIxParams(ixParams));
     }
-
   };
 
   buildSrcSet = (
@@ -88,11 +87,7 @@ class VueImgixClient implements IVueImgixClient {
     ixParams?: IImgixParams,
     options?: IBuildSrcSetOptions,
   ): string => {
-    return this.client.buildSrcSet(
-      url,
-      this.buildIxParams(ixParams),
-      options,
-    );
+    return this.client.buildSrcSet(url, this.buildIxParams(ixParams), options);
   };
 
   _buildSrcSet = (

--- a/tests/e2e/specs/static-api.spec.js
+++ b/tests/e2e/specs/static-api.spec.js
@@ -5,13 +5,27 @@ describe('Static API', () => {
       expect($image.attr('src')).to.match(/assets.imgix.net/);
       expect($image.attr('srcset')).to.match(/assets.imgix.net/);
     });
-  })
+  });
   it('should render image with an absolute URL', () => {
     cy.visit('/');
     cy.findByTestId('static-api-absolute').should(($image) => {
-      expect($image.attr('src')).to.match(/https:\/\/sdk-test.imgix.net\/amsterdam.jpg/,
+      expect($image.attr('src')).to.match(
+        /https:\/\/sdk-test.imgix.net\/amsterdam.jpg/,
       );
-      expect($image.attr('srcset')).to.match(/sdk-test.imgix.net\/amsterdam.jpg/);
+      expect($image.attr('srcset')).to.match(
+        /https:\/\/sdk-test.imgix.net\/amsterdam.jpg/,
+      );
     });
-  })
+  });
+  it('advanced buildSrcSet should accept absolute URLs', () => {
+    cy.visit('/');
+    cy.findByTestId('static-build-src-set').should(($image) => {
+      expect($image.attr('src')).to.match(
+        /https:\/\/sdk-test.imgix.net\/amsterdam.jpg/,
+      );
+      expect($image.attr('srcset')).to.match(
+        /https:\/\/sdk-test.imgix.net\/amsterdam.jpg/,
+      );
+    });
+  });
 });

--- a/tests/e2e/specs/static-api.spec.js
+++ b/tests/e2e/specs/static-api.spec.js
@@ -1,0 +1,17 @@
+describe('Static API', () => {
+  it('should render image with relative URL', () => {
+    cy.visit('/');
+    cy.findByTestId('static-api-relative').should(($image) => {
+      expect($image.attr('src')).to.match(/assets.imgix.net/);
+      expect($image.attr('srcset')).to.match(/assets.imgix.net/);
+    });
+  })
+  it('should render image with an absolute URL', () => {
+    cy.visit('/');
+    cy.findByTestId('static-api-absolute').should(($image) => {
+      expect($image.attr('src')).to.match(/https:\/\/sdk-test.imgix.net\/amsterdam.jpg/,
+      );
+      expect($image.attr('srcset')).to.match(/sdk-test.imgix.net\/amsterdam.jpg/);
+    });
+  })
+});

--- a/tests/unit/build-src-set.spec.ts
+++ b/tests/unit/build-src-set.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import {
   buildImgixClient,
-  IVueImgixClient
+  IVueImgixClient,
 } from '@/plugins/vue-imgix/vue-imgix';
 
 describe('buildSrcSet', () => {
@@ -89,70 +89,14 @@ describe('_buildSrcSet', () => {
   });
 
   it('builds an srcset list', () => {
-    const url = client._buildSrcSet('https://sdk-test.imgix.net/amsterdam.jpg', {});
+    const url = client._buildSrcSet(
+      'https://sdk-test.imgix.net/amsterdam.jpg',
+      {},
+    );
 
     const firstSrcSet = url.split(',')[0].split(' ');
     expect(firstSrcSet[0]).toMatch(/sdk-test.imgix.net\/amsterdam.jpg/);
     expect(firstSrcSet[0]).toMatch(/w=[0-9]/);
     expect(firstSrcSet[1]).toMatch(/^[0-9]+w$/);
-  });
-
-  // TODO: fix these tests
-  describe.skip('srcset generation', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let mockImgixClient: any;
-    let vueImgixClient: IVueImgixClient;
-    beforeEach(() => {
-      jest.resetModules();
-      jest.mock('@imgix/js-core');
-      const { buildImgixClient } = require('@/plugins/vue-imgix/');
-      const ImgixClient = require('@imgix/js-core');
-      mockImgixClient = {
-        settings: {},
-        _buildSrcSet: jest.fn(),
-        _buildURL: jest.fn(),
-      };
-      ImgixClient.mockImplementation(() => mockImgixClient);
-      vueImgixClient = buildImgixClient({
-        domain: 'testing.imgix.net',
-      });
-    });
-    afterAll(() => {
-      jest.resetAllMocks();
-      jest.resetModules();
-    });
-    it('custom widths are passed to @imgix/js-core', () => {
-      vueImgixClient._buildSrcSet('https://sdk-test.imgix.net/amsterdam.jpg', {}, { widths: [100, 200] });
-
-      expect(mockImgixClient._buildSrcSet).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.anything(),
-        expect.objectContaining({
-          widths: [100, 200],
-        }),
-      );
-    });
-    it('a custom width tolerance is passed to @imgix/js-core', () => {
-      vueImgixClient._buildSrcSet('https://sdk-test.imgix.net/amsterdam.jpg', {}, { widthTolerance: 0.2 });
-
-      expect(mockImgixClient._buildSrcSet).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.anything(),
-        expect.objectContaining({ widthTolerance: 0.2 }),
-      );
-    });
-    it('custom min/max widths are passed to @imgix/js-core', () => {
-      vueImgixClient._buildSrcSet(
-        'https://sdk-test.imgix.net/amsterdam.jpg',
-        {},
-        { minWidth: 500, maxWidth: 2000 },
-      );
-
-      expect(mockImgixClient._buildSrcSet).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.anything(),
-        expect.objectContaining({ minWidth: 500, maxWidth: 2000 }),
-      );
-    });
   });
 });

--- a/tests/unit/build-src-set.spec.ts
+++ b/tests/unit/build-src-set.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import {
   buildImgixClient,
-  IVueImgixClient,
+  IVueImgixClient
 } from '@/plugins/vue-imgix/vue-imgix';
 
 describe('buildSrcSet', () => {
@@ -72,6 +72,83 @@ describe('buildSrcSet', () => {
       );
 
       expect(mockImgixClient.buildSrcSet).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ minWidth: 500, maxWidth: 2000 }),
+      );
+    });
+  });
+});
+
+describe('_buildSrcSet', () => {
+  let client: IVueImgixClient;
+  beforeAll(() => {
+    client = buildImgixClient({
+      domain: 'assets.imgix.net',
+    });
+  });
+
+  it('builds an srcset list', () => {
+    const url = client._buildSrcSet('https://sdk-test.imgix.net/amsterdam.jpg', {});
+
+    const firstSrcSet = url.split(',')[0].split(' ');
+    expect(firstSrcSet[0]).toMatch(/sdk-test.imgix.net\/amsterdam.jpg/);
+    expect(firstSrcSet[0]).toMatch(/w=[0-9]/);
+    expect(firstSrcSet[1]).toMatch(/^[0-9]+w$/);
+  });
+
+  // TODO: fix these tests
+  describe.skip('srcset generation', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let mockImgixClient: any;
+    let vueImgixClient: IVueImgixClient;
+    beforeEach(() => {
+      jest.resetModules();
+      jest.mock('@imgix/js-core');
+      const { buildImgixClient } = require('@/plugins/vue-imgix/');
+      const ImgixClient = require('@imgix/js-core');
+      mockImgixClient = {
+        settings: {},
+        _buildSrcSet: jest.fn(),
+        _buildURL: jest.fn(),
+      };
+      ImgixClient.mockImplementation(() => mockImgixClient);
+      vueImgixClient = buildImgixClient({
+        domain: 'testing.imgix.net',
+      });
+    });
+    afterAll(() => {
+      jest.resetAllMocks();
+      jest.resetModules();
+    });
+    it('custom widths are passed to @imgix/js-core', () => {
+      vueImgixClient._buildSrcSet('https://sdk-test.imgix.net/amsterdam.jpg', {}, { widths: [100, 200] });
+
+      expect(mockImgixClient._buildSrcSet).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          widths: [100, 200],
+        }),
+      );
+    });
+    it('a custom width tolerance is passed to @imgix/js-core', () => {
+      vueImgixClient._buildSrcSet('https://sdk-test.imgix.net/amsterdam.jpg', {}, { widthTolerance: 0.2 });
+
+      expect(mockImgixClient._buildSrcSet).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ widthTolerance: 0.2 }),
+      );
+    });
+    it('custom min/max widths are passed to @imgix/js-core', () => {
+      vueImgixClient._buildSrcSet(
+        'https://sdk-test.imgix.net/amsterdam.jpg',
+        {},
+        { minWidth: 500, maxWidth: 2000 },
+      );
+
+      expect(mockImgixClient._buildSrcSet).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
         expect.objectContaining({ minWidth: 500, maxWidth: 2000 }),

--- a/tests/unit/build-url.spec.ts
+++ b/tests/unit/build-url.spec.ts
@@ -1,6 +1,6 @@
 import {
-  buildImgixClient,
-  IVueImgixClient,
+    buildImgixClient,
+    IVueImgixClient
 } from '@/plugins/vue-imgix/vue-imgix';
 
 describe('buildUrl', () => {
@@ -11,8 +11,17 @@ describe('buildUrl', () => {
     });
   });
 
-  it('builds an imgix url', () => {
+  it('should build an imgix url', () => {
     const url = client.buildUrl('/examples/pione.jpg', {});
     expect(url).toMatch(/assets.imgix.net\/examples\/pione.jpg/);
+  });
+
+  it('should accept absolute URLs', () => {
+    let customUrl = client._buildUrl(
+      'https://sdk-test.imgix.net/amsterdam.jpg',
+      {},
+    );
+
+    expect(customUrl).toMatch(/https:\/\/sdk-test.imgix.net\/amsterdam.jpg/);
   });
 });

--- a/tests/unit/build-url.spec.ts
+++ b/tests/unit/build-url.spec.ts
@@ -1,6 +1,6 @@
 import {
-    buildImgixClient,
-    IVueImgixClient
+  buildImgixClient,
+  IVueImgixClient,
 } from '@/plugins/vue-imgix/vue-imgix';
 
 describe('buildUrl', () => {
@@ -17,7 +17,7 @@ describe('buildUrl', () => {
   });
 
   it('should accept absolute URLs', () => {
-    let customUrl = client._buildUrl(
+    const customUrl = client._buildUrl(
       'https://sdk-test.imgix.net/amsterdam.jpg',
       {},
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1435,13 +1435,14 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@imgix/js-core@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@imgix/js-core/-/js-core-3.1.3.tgz#9c26366f84f59e6c238c41455f45aacdf04862b7"
-  integrity sha512-7HUIFy4dq9wLSJURgPhglSni50rt3af4cAyBip14koR5oPIGgTGs0W41aQZc5gyCesh7jZaSjm4VxiwqS7gszw==
+"@imgix/js-core@^3.6.0-rc.1":
+  version "3.6.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@imgix/js-core/-/js-core-3.6.0-rc.1.tgz#483b0aaf857186a4fba34b0bc7d995af5f871108"
+  integrity sha512-k0kSoZiVjHKFxgz/IFvW6KUH/SE4CZfT6huFmT2hU9RhFmZczXfk0ND6PzrElvFzmchrPLsGdgS9NdjWxmgUlg==
   dependencies:
-    js-base64 "~2.6.0"
+    js-base64 "~3.7.0"
     md5 "^2.2.1"
+    ufo "^0.7.10"
 
 "@intervolga/optimize-cssnano-plugin@^1.0.5":
   version "1.0.6"
@@ -8567,10 +8568,10 @@ joi@^17.4.0:
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
 
-js-base64@~2.6.0:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
-  integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
+js-base64@~3.7.0:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.2.tgz#816d11d81a8aff241603d19ce5761e13e41d7745"
+  integrity sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==
 
 js-beautify@^1.6.12:
   version "1.11.0"
@@ -12897,6 +12898,11 @@ typescript@~4.1.5:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.6.tgz#1becd85d77567c3c741172339e93ce2e69932138"
   integrity sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==
+
+ufo@^0.7.10:
+  version "0.7.11"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-0.7.11.tgz#17defad497981290383c5d26357773431fdbadcb"
+  integrity sha512-IT3q0lPvtkqQ8toHQN/BkOi4VIqoqheqM1FnkNWT9y0G8B3xJhwnoKBu5OHx8zHDOvveQzfKuFowJ0VSARiIDg==
 
 uglify-js@3.4.x:
   version "3.4.10"


### PR DESCRIPTION
This PR adds `_buildURL` and `_buildSrcSet` methods to the vue imgix client and enables users to use absolute URLs as the `img` src attribute. This means that users can override the imgix client domain on a per-image basis.

Fixes: #435 