### PR TITLE
tests: add back src set mocks

### DIFF
--- a/tests/unit/build-src-set.spec.ts
+++ b/tests/unit/build-src-set.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import {
   buildImgixClient,
-  IVueImgixClient
+  IVueImgixClient,
 } from '@/plugins/vue-imgix/vue-imgix';
 
 describe('buildSrcSet', () => {

--- a/tests/unit/build-src-set.spec.ts
+++ b/tests/unit/build-src-set.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import {
   buildImgixClient,
-  IVueImgixClient,
+  IVueImgixClient
 } from '@/plugins/vue-imgix/vue-imgix';
 
 describe('buildSrcSet', () => {
@@ -98,5 +98,73 @@ describe('_buildSrcSet', () => {
     expect(firstSrcSet[0]).toMatch(/sdk-test.imgix.net\/amsterdam.jpg/);
     expect(firstSrcSet[0]).toMatch(/w=[0-9]/);
     expect(firstSrcSet[1]).toMatch(/^[0-9]+w$/);
+  });
+
+  describe('srcset generation', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let mockImgixClient: any;
+    let vueImgixClient: IVueImgixClient;
+    let ImgixClient: IVueImgixClient;
+    beforeEach(() => {
+      jest.resetModules();
+      jest.mock('@imgix/js-core');
+      const { buildImgixClient } = require('@/plugins/vue-imgix/');
+      ImgixClient = require('@imgix/js-core');
+      mockImgixClient = {
+        settings: {},
+        _buildSrcSet: jest.fn(),
+        _buildURL: jest.fn(),
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (ImgixClient as any).mockImplementation(() => mockImgixClient);
+      vueImgixClient = buildImgixClient({
+        domain: 'testing.imgix.net',
+      });
+    });
+    afterAll(() => {
+      jest.resetAllMocks();
+      jest.resetModules();
+    });
+    it('custom widths are passed to @imgix/js-core', () => {
+      vueImgixClient._buildSrcSet(
+        'https://sdk-test.imgix.net/amsterdam.jpg',
+        {},
+        { widths: [100, 200] },
+      );
+
+      expect(ImgixClient._buildSrcSet).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          widths: [100, 200],
+        }),
+      );
+    });
+    it('a custom width tolerance is passed to @imgix/js-core', () => {
+      vueImgixClient._buildSrcSet(
+        'https://sdk-test.imgix.net/amsterdam.jpg',
+        {},
+        { widthTolerance: 0.2 },
+      );
+
+      expect(ImgixClient._buildSrcSet).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ widthTolerance: 0.2 }),
+      );
+    });
+    it('custom min/max widths are passed to @imgix/js-core', () => {
+      vueImgixClient._buildSrcSet(
+        'https://sdk-test.imgix.net/amsterdam.jpg',
+        {},
+        { minWidth: 500, maxWidth: 2000 },
+      );
+
+      expect(ImgixClient._buildSrcSet).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ minWidth: 500, maxWidth: 2000 }),
+      );
+    });
   });
 });


### PR DESCRIPTION
This PR adds back the srcset tests that were removed in https://github.com/imgix/vue-imgix/commit/78ce8cf886b852065523fe36b7d8acfa07fc9a0f
